### PR TITLE
Add service model for Amazon Polly

### DIFF
--- a/codegen/aws-models/polly.json
+++ b/codegen/aws-models/polly.json
@@ -1,0 +1,4067 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.polly#Alphabet": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#AudioChunk": {
+            "type": "blob"
+        },
+        "com.amazonaws.polly#AudioEvent": {
+            "type": "structure",
+            "members": {
+                "AudioChunk": {
+                    "target": "com.amazonaws.polly#AudioChunk",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A chunk of synthesized audio data encoded in the format specified by the \n      <code>OutputFormat</code> parameter.</p>",
+                        "smithy.api#eventPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains a chunk of synthesized audio data.</p>"
+            }
+        },
+        "com.amazonaws.polly#AudioStream": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.polly#AvailabilityErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#CloseStreamEvent": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Indicates the end of the input stream. After sending this event, the input stream\n     will be closed and all audio will be returned.</p>"
+            }
+        },
+        "com.amazonaws.polly#ContentType": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#CoralAvailabilityThrottledResource": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#CoralAvailabilityThrottlingReason": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#DateTime": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.polly#DeleteLexicon": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#DeleteLexiconInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#DeleteLexiconOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#LexiconNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the specified pronunciation lexicon stored in an Amazon Web Services Region. A lexicon which has been deleted is not available for\n      speech synthesis, nor is it possible to retrieve it using either the\n        <code>GetLexicon</code> or <code>ListLexicon</code> APIs.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To delete a lexicon",
+                        "documentation": "Deletes a specified pronunciation lexicon stored in an AWS Region.",
+                        "input": {
+                            "Name": "example"
+                        },
+                        "output": {}
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v1/lexicons/{Name}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#DeleteLexiconInput": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.polly#LexiconName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the lexicon to delete. Must be an existing lexicon in\n      the region.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#DeleteLexiconOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#DescribeVoices": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#DescribeVoicesInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#DescribeVoicesOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#InvalidNextTokenException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the list of voices that are available for use when\n      requesting speech synthesis. Each voice speaks a specified language, is\n      either male or female, and is identified by an ID, which is the ASCII\n      version of the voice name. </p>\n         <p>When synthesizing speech ( <code>SynthesizeSpeech</code> ), you\n      provide the voice ID for the voice you want from the list of voices\n      returned by <code>DescribeVoices</code>.</p>\n         <p>For example, you want your news reader application to read news in\n      a specific language, but giving a user the option to choose the voice.\n      Using the <code>DescribeVoices</code> operation you can provide the user\n      with a list of available voices to select from.</p>\n         <p> You can optionally specify a language code to filter the available\n      voices. For example, if you specify <code>en-US</code>, the operation\n      returns a list of all available US English voices. </p>\n         <p>This operation requires permissions to perform the\n        <code>polly:DescribeVoices</code> action.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To describe available voices",
+                        "documentation": "Returns the list of voices that are available for use when requesting speech synthesis. Displayed languages are those within the specified language code. If no language code is specified, voices for all available languages are displayed.",
+                        "input": {
+                            "LanguageCode": "en-GB"
+                        },
+                        "output": {
+                            "Voices": [
+                                {
+                                    "Gender": "Female",
+                                    "Name": "Emma",
+                                    "LanguageName": "British English",
+                                    "Id": "Emma",
+                                    "LanguageCode": "en-GB"
+                                },
+                                {
+                                    "Gender": "Male",
+                                    "Name": "Brian",
+                                    "LanguageName": "British English",
+                                    "Id": "Brian",
+                                    "LanguageCode": "en-GB"
+                                },
+                                {
+                                    "Gender": "Female",
+                                    "Name": "Amy",
+                                    "LanguageName": "British English",
+                                    "Id": "Amy",
+                                    "LanguageCode": "en-GB"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/voices",
+                    "code": 200
+                },
+                "smithy.test#smokeTests": [
+                    {
+                        "id": "DescribeVoicesSuccess",
+                        "params": {},
+                        "vendorParams": {
+                            "region": "us-west-2"
+                        },
+                        "vendorParamsShape": "aws.test#AwsVendorParams",
+                        "expect": {
+                            "success": {}
+                        }
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.polly#DescribeVoicesInput": {
+            "type": "structure",
+            "members": {
+                "Engine": {
+                    "target": "com.amazonaws.polly#Engine",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the engine (<code>standard</code>, <code>neural</code>,\n      <code>long-form</code> or <code>generative</code>) used by Amazon Polly when\n      processing input text for speech synthesis. </p>",
+                        "smithy.api#httpQuery": "Engine"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The language identification tag (ISO 639 code for the language\n      name-ISO 3166 country code) for filtering the list of voices returned. If\n      you don't specify this optional parameter, all available voices are\n      returned. </p>",
+                        "smithy.api#httpQuery": "LanguageCode"
+                    }
+                },
+                "IncludeAdditionalLanguageCodes": {
+                    "target": "com.amazonaws.polly#IncludeAdditionalLanguageCodes",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Boolean value indicating whether to return any bilingual voices that\n      use the specified language as an additional language. For instance, if you\n      request all languages that use US English (es-US), and there is an Italian\n      voice that speaks both Italian (it-IT) and US English, that voice will be\n      included if you specify <code>yes</code> but not if you specify\n        <code>no</code>.</p>",
+                        "smithy.api#httpQuery": "IncludeAdditionalLanguageCodes"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token returned from the previous\n        <code>DescribeVoices</code> operation. If present, this indicates where\n      to continue the listing.</p>",
+                        "smithy.api#httpQuery": "NextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#DescribeVoicesOutput": {
+            "type": "structure",
+            "members": {
+                "Voices": {
+                    "target": "com.amazonaws.polly#VoiceList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of voices with their properties.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in the next request to continue the\n      listing of voices. <code>NextToken</code> is returned only if the response\n      is truncated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#Engine": {
+            "type": "enum",
+            "members": {
+                "STANDARD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "standard"
+                    }
+                },
+                "NEURAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "neural"
+                    }
+                },
+                "LONG_FORM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "long-form"
+                    }
+                },
+                "GENERATIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "generative"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#EngineList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#Engine"
+            }
+        },
+        "com.amazonaws.polly#EngineNotSupportedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This engine is not compatible with the voice that you have designated.\n      Choose a new voice that is compatible with the engine or change the engine\n      and restart the operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#FlushStreamConfiguration": {
+            "type": "structure",
+            "members": {
+                "Force": {
+                    "target": "com.amazonaws.polly#Force",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether to force the synthesis engine to immediately \n      write buffered audio data to the output stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration that controls when synthesized audio data is sent on the output stream.</p>"
+            }
+        },
+        "com.amazonaws.polly#Force": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.polly#Gender": {
+            "type": "enum",
+            "members": {
+                "Female": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Female"
+                    }
+                },
+                "Male": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Male"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#GetLexicon": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#GetLexiconInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#GetLexiconOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#LexiconNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the content of the specified pronunciation lexicon stored\n      in an Amazon Web Services Region. For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/lexicons/{Name}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#GetLexiconInput": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.polly#LexiconName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the lexicon.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#GetLexiconOutput": {
+            "type": "structure",
+            "members": {
+                "Lexicon": {
+                    "target": "com.amazonaws.polly#Lexicon",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Lexicon object that provides name and the string content of the\n      lexicon. </p>"
+                    }
+                },
+                "LexiconAttributes": {
+                    "target": "com.amazonaws.polly#LexiconAttributes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Metadata of the lexicon, including phonetic alphabetic used,\n      language code, lexicon ARN, number of lexemes defined in the lexicon, and\n      size of lexicon in bytes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#GetSpeechSynthesisTask": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#GetSpeechSynthesisTaskInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#GetSpeechSynthesisTaskOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#InvalidTaskIdException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                {
+                    "target": "com.amazonaws.polly#SynthesisTaskNotFoundException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves a specific SpeechSynthesisTask object based on its TaskID.\n      This object contains information about the given speech synthesis task,\n      including the status of the task, and a link to the S3 bucket containing\n      the output of the task.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/synthesisTasks/{TaskId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#GetSpeechSynthesisTaskInput": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.polly#TaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Polly generated identifier for a speech synthesis task.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#GetSpeechSynthesisTaskOutput": {
+            "type": "structure",
+            "members": {
+                "SynthesisTask": {
+                    "target": "com.amazonaws.polly#SynthesisTask",
+                    "traits": {
+                        "smithy.api#documentation": "<p>SynthesisTask object that provides information from the requested\n      task, including output format, creation time, task status, and so\n      on.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#IncludeAdditionalLanguageCodes": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.polly#InvalidLexiconException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Amazon Polly can't find the specified lexicon. Verify that the lexicon's\n      name is spelled correctly, and then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidNextTokenException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The NextToken is invalid. Verify that it's spelled correctly, and\n      then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidS3BucketException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The provided Amazon S3 bucket name is invalid. Please check your input\n      with S3 bucket naming requirements and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidS3KeyException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The provided Amazon S3 key prefix is invalid. Please provide a valid\n      S3 object key name.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidSampleRateException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The specified sample rate is not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidSnsTopicArnException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The provided SNS topic ARN is invalid. Please provide a valid SNS\n      topic ARN and try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidSsmlException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The SSML you provided is invalid. Verify the SSML syntax, spelling\n      of tags and values, and then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#InvalidTaskIdException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The provided Task ID is not valid. Please provide a valid Task ID and\n      try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#LanguageCode": {
+            "type": "enum",
+            "members": {
+                "arb": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "arb"
+                    }
+                },
+                "cmn_CN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cmn-CN"
+                    }
+                },
+                "cy_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cy-GB"
+                    }
+                },
+                "da_DK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "da-DK"
+                    }
+                },
+                "de_DE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "de-DE"
+                    }
+                },
+                "en_AU": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-AU"
+                    }
+                },
+                "en_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-GB"
+                    }
+                },
+                "en_GB_WLS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-GB-WLS"
+                    }
+                },
+                "en_IN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-IN"
+                    }
+                },
+                "en_US": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-US"
+                    }
+                },
+                "es_ES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "es-ES"
+                    }
+                },
+                "es_MX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "es-MX"
+                    }
+                },
+                "es_US": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "es-US"
+                    }
+                },
+                "fr_CA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "fr-CA"
+                    }
+                },
+                "fr_FR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "fr-FR"
+                    }
+                },
+                "is_IS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "is-IS"
+                    }
+                },
+                "it_IT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "it-IT"
+                    }
+                },
+                "ja_JP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ja-JP"
+                    }
+                },
+                "hi_IN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "hi-IN"
+                    }
+                },
+                "ko_KR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ko-KR"
+                    }
+                },
+                "nb_NO": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "nb-NO"
+                    }
+                },
+                "nl_NL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "nl-NL"
+                    }
+                },
+                "pl_PL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "pl-PL"
+                    }
+                },
+                "pt_BR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "pt-BR"
+                    }
+                },
+                "pt_PT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "pt-PT"
+                    }
+                },
+                "ro_RO": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ro-RO"
+                    }
+                },
+                "ru_RU": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ru-RU"
+                    }
+                },
+                "sv_SE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sv-SE"
+                    }
+                },
+                "tr_TR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "tr-TR"
+                    }
+                },
+                "en_NZ": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-NZ"
+                    }
+                },
+                "en_ZA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-ZA"
+                    }
+                },
+                "ca_ES": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-ES"
+                    }
+                },
+                "de_AT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "de-AT"
+                    }
+                },
+                "yue_CN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "yue-CN"
+                    }
+                },
+                "ar_AE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ar-AE"
+                    }
+                },
+                "fi_FI": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "fi-FI"
+                    }
+                },
+                "en_IE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-IE"
+                    }
+                },
+                "nl_BE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "nl-BE"
+                    }
+                },
+                "fr_BE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "fr-BE"
+                    }
+                },
+                "cs_CZ": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "cs-CZ"
+                    }
+                },
+                "de_CH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "de-CH"
+                    }
+                },
+                "en_SG": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "en-SG"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#LanguageCodeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#LanguageCode"
+            }
+        },
+        "com.amazonaws.polly#LanguageName": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#LanguageNotSupportedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The language specified is not currently supported by Amazon Polly in this\n      capacity.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#LastModified": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.polly#LexemesCount": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.polly#Lexicon": {
+            "type": "structure",
+            "members": {
+                "Content": {
+                    "target": "com.amazonaws.polly#LexiconContent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Lexicon content in string format. The content of a lexicon must be\n      in PLS format.</p>"
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.polly#LexiconName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the lexicon.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides lexicon name and lexicon content in string format. For\n      more information, see <a href=\"https://www.w3.org/TR/pronunciation-lexicon/\">Pronunciation Lexicon\n        Specification (PLS) Version 1.0</a>.</p>"
+            }
+        },
+        "com.amazonaws.polly#LexiconArn": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#LexiconAttributes": {
+            "type": "structure",
+            "members": {
+                "Alphabet": {
+                    "target": "com.amazonaws.polly#Alphabet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Phonetic alphabet used in the lexicon. Valid values are\n        <code>ipa</code> and <code>x-sampa</code>.</p>"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Language code that the lexicon applies to. A lexicon with a\n      language code such as \"en\" would be applied to all English languages\n      (en-GB, en-US, en-AUS, en-WLS, and so on.</p>"
+                    }
+                },
+                "LastModified": {
+                    "target": "com.amazonaws.polly#LastModified",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Date lexicon was last modified (a timestamp value).</p>"
+                    }
+                },
+                "LexiconArn": {
+                    "target": "com.amazonaws.polly#LexiconArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the lexicon.</p>"
+                    }
+                },
+                "LexemesCount": {
+                    "target": "com.amazonaws.polly#LexemesCount",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Number of lexemes in the lexicon.</p>"
+                    }
+                },
+                "Size": {
+                    "target": "com.amazonaws.polly#Size",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Total size of the lexicon, in characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains metadata describing the lexicon such as the number of\n      lexemes, language code, and so on. For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>"
+            }
+        },
+        "com.amazonaws.polly#LexiconContent": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.polly#LexiconDescription": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.polly#LexiconName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the lexicon.</p>"
+                    }
+                },
+                "Attributes": {
+                    "target": "com.amazonaws.polly#LexiconAttributes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides lexicon metadata.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes the content of the lexicon.</p>"
+            }
+        },
+        "com.amazonaws.polly#LexiconDescriptionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#LexiconDescription"
+            }
+        },
+        "com.amazonaws.polly#LexiconName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9A-Za-z]{1,20}$"
+            }
+        },
+        "com.amazonaws.polly#LexiconNameList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#LexiconName"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 5
+                }
+            }
+        },
+        "com.amazonaws.polly#LexiconNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Amazon Polly can't find the specified lexicon. This could be caused by a\n      lexicon that is missing, its name is misspelled or specifying a lexicon\n      that is in a different region.</p>\n         <p>Verify that the lexicon exists, is in the region (see <a>ListLexicons</a>) and that you spelled its name is spelled\n      correctly. Then try again.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.polly#LexiconSizeExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The maximum size of the specified lexicon would be exceeded by this\n      operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#ListLexicons": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#ListLexiconsInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#ListLexiconsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#InvalidNextTokenException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a list of pronunciation lexicons stored in an Amazon Web Services Region. For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To list all lexicons in a region",
+                        "documentation": "Returns a list of pronunciation lexicons stored in an AWS Region.",
+                        "output": {
+                            "Lexicons": [
+                                {
+                                    "Attributes": {
+                                        "LanguageCode": "en-US",
+                                        "LastModified": 1.478542980117E9,
+                                        "Alphabet": "ipa",
+                                        "LexemesCount": 1,
+                                        "LexiconArn": "arn:aws:polly:us-east-1:123456789012:lexicon/example",
+                                        "Size": 503
+                                    },
+                                    "Name": "example"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/lexicons",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#ListLexiconsInput": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token returned from previous\n        <code>ListLexicons</code> operation. If present, indicates where to\n      continue the list of lexicons.</p>",
+                        "smithy.api#httpQuery": "NextToken"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#ListLexiconsOutput": {
+            "type": "structure",
+            "members": {
+                "Lexicons": {
+                    "target": "com.amazonaws.polly#LexiconDescriptionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of lexicon names and attributes.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in the next request to continue the\n      listing of lexicons. <code>NextToken</code> is returned only if the\n      response is truncated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#ListSpeechSynthesisTasks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#ListSpeechSynthesisTasksInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#ListSpeechSynthesisTasksOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#InvalidNextTokenException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a list of SpeechSynthesisTask objects ordered by their\n      creation date. This operation can filter the tasks by their status, for\n      example, allowing users to list only tasks that are completed.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v1/synthesisTasks",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.polly#ListSpeechSynthesisTasksInput": {
+            "type": "structure",
+            "members": {
+                "MaxResults": {
+                    "target": "com.amazonaws.polly#MaxResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Maximum number of speech synthesis tasks returned in a List\n      operation.</p>",
+                        "smithy.api#httpQuery": "MaxResults"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token to use in the next request to continue the\n      listing of speech synthesis tasks. </p>",
+                        "smithy.api#httpQuery": "NextToken"
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.polly#TaskStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status of the speech synthesis tasks returned in a List\n      operation</p>",
+                        "smithy.api#httpQuery": "Status"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#ListSpeechSynthesisTasksOutput": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.polly#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An opaque pagination token returned from the previous List operation\n      in this request. If present, this indicates where to continue the\n      listing.</p>"
+                    }
+                },
+                "SynthesisTasks": {
+                    "target": "com.amazonaws.polly#SynthesisTasks",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of SynthesisTask objects that provides information from the\n      specified task in the list request, including output format, creation\n      time, task status, and so on.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#MarksNotSupportedForFormatException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Speech marks are not supported for the <code>OutputFormat</code>\n      selected. Speech marks are only available for content in <code>json</code>\n      format.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#MaxLexemeLengthExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The maximum size of the lexeme would be exceeded by this\n      operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#MaxLexiconsNumberExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The maximum number of lexicons would be exceeded by this\n      operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#MaxResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.polly#NextToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4096
+                }
+            }
+        },
+        "com.amazonaws.polly#OutputFormat": {
+            "type": "enum",
+            "members": {
+                "JSON": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "json"
+                    }
+                },
+                "MP3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mp3"
+                    }
+                },
+                "OGG_OPUS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ogg_opus"
+                    }
+                },
+                "OGG_VORBIS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ogg_vorbis"
+                    }
+                },
+                "PCM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "pcm"
+                    }
+                },
+                "MULAW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mulaw"
+                    }
+                },
+                "ALAW": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "alaw"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#OutputS3BucketName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+            }
+        },
+        "com.amazonaws.polly#OutputS3KeyPrefix": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[0-9a-zA-Z\\/\\!\\-_\\.\\*\\'\\(\\):;\\$@=+\\,\\?&]{0,800}$"
+            }
+        },
+        "com.amazonaws.polly#OutputUri": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#Parrot_v1": {
+            "type": "service",
+            "version": "2016-06-10",
+            "operations": [
+                {
+                    "target": "com.amazonaws.polly#DeleteLexicon"
+                },
+                {
+                    "target": "com.amazonaws.polly#DescribeVoices"
+                },
+                {
+                    "target": "com.amazonaws.polly#GetLexicon"
+                },
+                {
+                    "target": "com.amazonaws.polly#GetSpeechSynthesisTask"
+                },
+                {
+                    "target": "com.amazonaws.polly#ListLexicons"
+                },
+                {
+                    "target": "com.amazonaws.polly#ListSpeechSynthesisTasks"
+                },
+                {
+                    "target": "com.amazonaws.polly#PutLexicon"
+                },
+                {
+                    "target": "com.amazonaws.polly#StartSpeechSynthesisStream"
+                },
+                {
+                    "target": "com.amazonaws.polly#StartSpeechSynthesisTask"
+                },
+                {
+                    "target": "com.amazonaws.polly#SynthesizeSpeech"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "Polly",
+                    "arnNamespace": "polly",
+                    "cloudFormationName": "Polly",
+                    "cloudTrailEventSource": "polly.amazonaws.com",
+                    "endpointPrefix": "polly"
+                },
+                "aws.auth#sigv4": {
+                    "name": "polly"
+                },
+                "aws.protocols#restJson1": {
+                    "http": [
+                        "http/1.1",
+                        "h2"
+                    ],
+                    "eventStreamHttp": [
+                        "h2"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Amazon Polly is a web service that makes it easy to synthesize speech from\n      text.</p>\n         <p>The Amazon Polly service provides API operations for synthesizing\n      high-quality speech from plain text and Speech Synthesis Markup Language\n      (SSML), along with managing pronunciations lexicons that enable you to get\n      the best results for your application domain.</p>",
+                "smithy.api#title": "Amazon Polly",
+                "smithy.api#xmlNamespace": {
+                    "uri": "http://polly.amazonaws.com/doc/v1"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseDualStack"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": {
+                                            "ref": "Endpoint"
+                                        },
+                                        "properties": {},
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "aws.partition",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ],
+                                            "assign": "PartitionResult"
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://polly-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseFIPS"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsFIPS"
+                                                                    ]
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://polly-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                true,
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "supportsDualStack"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://polly.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                    "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": "https://polly.{Region}.{PartitionResult#dnsSuffix}",
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                }
+                            ],
+                            "type": "tree"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.af-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "af-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-northeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-northeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-southeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.polly#PutLexicon": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#PutLexiconInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#PutLexiconOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#InvalidLexiconException"
+                },
+                {
+                    "target": "com.amazonaws.polly#LexiconSizeExceededException"
+                },
+                {
+                    "target": "com.amazonaws.polly#MaxLexemeLengthExceededException"
+                },
+                {
+                    "target": "com.amazonaws.polly#MaxLexiconsNumberExceededException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                {
+                    "target": "com.amazonaws.polly#UnsupportedPlsAlphabetException"
+                },
+                {
+                    "target": "com.amazonaws.polly#UnsupportedPlsLanguageException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Stores a pronunciation lexicon in an Amazon Web Services Region. If\n      a lexicon with the same name already exists in the region, it is\n      overwritten by the new lexicon. Lexicon operations have eventual\n      consistency, therefore, it might take some time before the lexicon is\n      available to the SynthesizeSpeech operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To save a lexicon",
+                        "documentation": "Stores a pronunciation lexicon in an AWS Region.",
+                        "input": {
+                            "Name": "W3C",
+                            "Content": "<Lexicon Content>"
+                        },
+                        "output": {}
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v1/lexicons/{Name}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#PutLexiconInput": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.polly#LexiconName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the lexicon. The name must follow the regular express\n      format [0-9A-Za-z]{1,20}. That is, the name is a case-sensitive\n      alphanumeric string up to 20 characters long. </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Content": {
+                    "target": "com.amazonaws.polly#LexiconContent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Content of the PLS lexicon as string data.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#PutLexiconOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#QuotaCode": {
+            "type": "enum",
+            "members": {
+                "INPUT_STREAM_INBOUND_EVENT_TIMEOUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "input-stream-inbound-event-timeout"
+                    }
+                },
+                "INPUT_STREAM_TIMEOUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "input-stream-timeout"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#RequestCharacters": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.polly#SampleRate": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#ServiceCode": {
+            "type": "enum",
+            "members": {
+                "POLLY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "polly"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#ServiceFailureException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An unknown condition has caused a service failure.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.polly#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "quotaCode": {
+                    "target": "com.amazonaws.polly#QuotaCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota code identifying the specific quota.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "serviceCode": {
+                    "target": "com.amazonaws.polly#ServiceCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The service code identifying the originating service.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request would cause a service quota to be exceeded.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.polly#Size": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.polly#SnsTopicArn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^arn:aws(-(cn|iso(-b)?|us-gov))?:sns:[a-z0-9_-]{1,50}:\\d{12}:[a-zA-Z0-9_-]{1,251}([a-zA-Z0-9_-]{0,5}|\\.fifo)$"
+            }
+        },
+        "com.amazonaws.polly#SpeechMarkType": {
+            "type": "enum",
+            "members": {
+                "SENTENCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "sentence"
+                    }
+                },
+                "SSML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ssml"
+                    }
+                },
+                "VISEME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "viseme"
+                    }
+                },
+                "WORD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "word"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#SpeechMarkTypeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#SpeechMarkType"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 4
+                }
+            }
+        },
+        "com.amazonaws.polly#SsmlMarksNotSupportedForTextTypeException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>SSML speech marks are not supported for plain text-type\n      input.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#StartSpeechSynthesisStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#StartSpeechSynthesisStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Synthesizes UTF-8 input, plain text, or SSML over a bidirectional streaming connection. \n      Specify synthesis parameters in HTTP/2 headers, send text incrementally as events on the input stream,\n       and receive synthesized audio as it becomes available.</p>\n         <p>This operation serves as a bidirectional counterpart to <code>SynthesizeSpeech</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/polly/latest/API/API_SynthesizeSpeech.html\">SynthesizeSpeech</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/synthesisStream",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisStreamActionStream": {
+            "type": "union",
+            "members": {
+                "TextEvent": {
+                    "target": "com.amazonaws.polly#TextEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A text event containing content to be synthesized.</p>"
+                    }
+                },
+                "CloseStreamEvent": {
+                    "target": "com.amazonaws.polly#CloseStreamEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An event indicating the end of the input stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Inbound event stream for sending input and control events to manage bidirectional speech synthesis.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisStreamEventStream": {
+            "type": "union",
+            "members": {
+                "AudioEvent": {
+                    "target": "com.amazonaws.polly#AudioEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An audio event containing synthesized speech.</p>"
+                    }
+                },
+                "StreamClosedEvent": {
+                    "target": "com.amazonaws.polly#StreamClosedEvent",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An event, with summary information, indicating the stream has closed.</p>"
+                    }
+                },
+                "ValidationException": {
+                    "target": "com.amazonaws.polly#ValidationException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An exception indicating the input failed validation.</p>"
+                    }
+                },
+                "ServiceQuotaExceededException": {
+                    "target": "com.amazonaws.polly#ServiceQuotaExceededException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An exception indicating a service quota would be exceeded.</p>"
+                    }
+                },
+                "ServiceFailureException": {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                "ThrottlingException": {
+                    "target": "com.amazonaws.polly#ThrottlingException",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An exception indicating the request was throttled.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Outbound event stream that contains synthesized audio data and stream status events.</p>",
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisStreamInput": {
+            "type": "structure",
+            "members": {
+                "Engine": {
+                    "target": "com.amazonaws.polly#Engine",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the engine for Amazon Polly to use when processing input text for speech synthesis. \n      Currently, only the <code>generative</code> engine is supported.\n      If you specify a voice that the selected engine doesn't support, Amazon Polly returns an error.</p>",
+                        "smithy.api#httpHeader": "x-amzn-Engine",
+                        "smithy.api#required": {}
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An optional parameter that sets the language code for the speech synthesis request. Specify this parameter only \n      when using a bilingual voice. If a bilingual voice is used and no language code is specified, Amazon Polly \n      uses the default language of the bilingual voice.</p>",
+                        "smithy.api#httpHeader": "x-amzn-LanguageCode"
+                    }
+                },
+                "LexiconNames": {
+                    "target": "com.amazonaws.polly#LexiconNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The names of one or more pronunciation lexicons for the service to apply \n      during synthesis. Amazon Polly applies lexicons only when the lexicon language matches the voice language.</p>",
+                        "smithy.api#httpHeader": "x-amzn-LexiconNames"
+                    }
+                },
+                "OutputFormat": {
+                    "target": "com.amazonaws.polly#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio format for the synthesized speech. Currently, Amazon Polly does not support JSON speech marks.</p>",
+                        "smithy.api#httpHeader": "x-amzn-OutputFormat",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SampleRate": {
+                    "target": "com.amazonaws.polly#SampleRate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio frequency, specified in Hz.</p>",
+                        "smithy.api#httpHeader": "x-amzn-SampleRate"
+                    }
+                },
+                "VoiceId": {
+                    "target": "com.amazonaws.polly#VoiceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The voice to use in synthesis. To get a list of available voice IDs, use the <a href=\"https://docs.aws.amazon.com/polly/latest/API/API_DescribeVoices.html\">DescribeVoices</a> operation.</p>",
+                        "smithy.api#httpHeader": "x-amzn-VoiceId",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ActionStream": {
+                    "target": "com.amazonaws.polly#StartSpeechSynthesisStreamActionStream",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input event stream that contains text events and stream control events.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisStreamOutput": {
+            "type": "structure",
+            "members": {
+                "EventStream": {
+                    "target": "com.amazonaws.polly#StartSpeechSynthesisStreamEventStream",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The output event stream that contains synthesized audio events and stream status events.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisTask": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#StartSpeechSynthesisTaskInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#StartSpeechSynthesisTaskOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#EngineNotSupportedException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidS3BucketException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidS3KeyException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidSampleRateException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidSnsTopicArnException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidSsmlException"
+                },
+                {
+                    "target": "com.amazonaws.polly#LanguageNotSupportedException"
+                },
+                {
+                    "target": "com.amazonaws.polly#LexiconNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.polly#MarksNotSupportedForFormatException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                {
+                    "target": "com.amazonaws.polly#SsmlMarksNotSupportedForTextTypeException"
+                },
+                {
+                    "target": "com.amazonaws.polly#TextLengthExceededException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Allows the creation of an asynchronous synthesis task, by starting a\n      new <code>SpeechSynthesisTask</code>. This operation requires all the\n      standard information needed for speech synthesis, plus the name of an\n      Amazon S3 bucket for the service to store the output of the synthesis task\n      and two optional parameters (<code>OutputS3KeyPrefix</code> and\n        <code>SnsTopicArn</code>). Once the synthesis task is created, this\n      operation will return a <code>SpeechSynthesisTask</code> object, which\n      will include an identifier of this task as well as the current status. The\n        <code>SpeechSynthesisTask</code> object is available for 72 hours after\n      starting the asynchronous synthesis task.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/synthesisTasks",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisTaskInput": {
+            "type": "structure",
+            "members": {
+                "Engine": {
+                    "target": "com.amazonaws.polly#Engine",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the engine (<code>standard</code>, <code>neural</code>,\n      <code>long-form</code> or <code>generative</code>) for Amazon Polly to use\n      when processing input text for speech synthesis. Using a voice that\n      is not supported for the engine selected will result in an error.</p>"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional language code for the Speech Synthesis request. This is only\n      necessary if using a bilingual voice, such as Aditi, which can be used for\n      either Indian English (en-IN) or Hindi (hi-IN). </p>\n         <p>If a bilingual voice is used and no language code is specified, Amazon Polly\n      uses the default language of the bilingual voice. The default language for\n      any voice is the one returned by the <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_DescribeVoices.html\">DescribeVoices</a> operation for the <code>LanguageCode</code>\n      parameter. For example, if no language code is specified, Aditi will use\n      Indian English rather than Hindi.</p>"
+                    }
+                },
+                "LexiconNames": {
+                    "target": "com.amazonaws.polly#LexiconNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of one or more pronunciation lexicon names you want the service\n      to apply during synthesis. Lexicons are applied only if the language of\n      the lexicon is the same as the language of the voice. </p>"
+                    }
+                },
+                "OutputFormat": {
+                    "target": "com.amazonaws.polly#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format in which the returned output will be encoded. For audio\n      stream, this will be mp3, ogg_vorbis, ogg_opus, mu-law, a-law, or pcm. For speech marks, this will\n      be json. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "OutputS3BucketName": {
+                    "target": "com.amazonaws.polly#OutputS3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon S3 bucket name to which the output file will be saved.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "OutputS3KeyPrefix": {
+                    "target": "com.amazonaws.polly#OutputS3KeyPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon S3 key prefix for the output speech file.</p>"
+                    }
+                },
+                "SampleRate": {
+                    "target": "com.amazonaws.polly#SampleRate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio frequency specified in Hz.</p>\n         <p>The valid values for mp3 and ogg_vorbis are \"8000\", \"16000\", \"22050\",\n      and \"24000\". The default value for standard voices is \"22050\". The default\n      value for neural voices is \"24000\". The default value for long-form voices\n      is \"24000\". The default value for generative voices is \"24000\".</p>\n         <p>Valid values for pcm are \"8000\" and \"16000\" The default value is\n      \"16000\". </p>\n         <p>Valid value for ogg_opus is \"48000\". </p>\n         <p>Valid value for mu-law and a-law is \"8000\". </p>"
+                    }
+                },
+                "SnsTopicArn": {
+                    "target": "com.amazonaws.polly#SnsTopicArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ARN for the SNS topic optionally used for providing status\n      notification for a speech synthesis task.</p>"
+                    }
+                },
+                "SpeechMarkTypes": {
+                    "target": "com.amazonaws.polly#SpeechMarkTypeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of speech marks returned for the input text.</p>"
+                    }
+                },
+                "Text": {
+                    "target": "com.amazonaws.polly#Text",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input text to synthesize. If you specify ssml as the TextType,\n      follow the SSML format for the input text. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TextType": {
+                    "target": "com.amazonaws.polly#TextType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether the input text is plain text or SSML. The default\n      value is plain text. </p>"
+                    }
+                },
+                "VoiceId": {
+                    "target": "com.amazonaws.polly#VoiceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Voice ID to use for the synthesis. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#StartSpeechSynthesisTaskOutput": {
+            "type": "structure",
+            "members": {
+                "SynthesisTask": {
+                    "target": "com.amazonaws.polly#SynthesisTask",
+                    "traits": {
+                        "smithy.api#documentation": "<p>SynthesisTask object that provides information and attributes about a\n      newly submitted speech synthesis task.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#StreamClosedEvent": {
+            "type": "structure",
+            "members": {
+                "RequestCharacters": {
+                    "target": "com.amazonaws.polly#RequestCharacters",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The total number of characters synthesized during the streaming session.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Indicates that the synthesis stream is closed and provides summary information.</p>"
+            }
+        },
+        "com.amazonaws.polly#SynthesisTask": {
+            "type": "structure",
+            "members": {
+                "Engine": {
+                    "target": "com.amazonaws.polly#Engine",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the engine (<code>standard</code>, <code>neural</code>,\n      <code>long-form</code> or <code>generative</code>) for Amazon Polly to use\n      when processing input text for speech synthesis. Using a voice that\n      is not supported for the engine selected will result in an error.</p>"
+                    }
+                },
+                "TaskId": {
+                    "target": "com.amazonaws.polly#TaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Polly generated identifier for a speech synthesis task.</p>"
+                    }
+                },
+                "TaskStatus": {
+                    "target": "com.amazonaws.polly#TaskStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Current status of the individual speech synthesis task.</p>"
+                    }
+                },
+                "TaskStatusReason": {
+                    "target": "com.amazonaws.polly#TaskStatusReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Reason for the current status of a specific speech synthesis task,\n      including errors if the task has failed.</p>"
+                    }
+                },
+                "OutputUri": {
+                    "target": "com.amazonaws.polly#OutputUri",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Pathway for the output speech file.</p>"
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.polly#DateTime",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Timestamp for the time the synthesis task was started.</p>"
+                    }
+                },
+                "RequestCharacters": {
+                    "target": "com.amazonaws.polly#RequestCharacters",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Number of billable characters synthesized.</p>"
+                    }
+                },
+                "SnsTopicArn": {
+                    "target": "com.amazonaws.polly#SnsTopicArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ARN for the SNS topic optionally used for providing status\n      notification for a speech synthesis task.</p>"
+                    }
+                },
+                "LexiconNames": {
+                    "target": "com.amazonaws.polly#LexiconNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of one or more pronunciation lexicon names you want the service\n      to apply during synthesis. Lexicons are applied only if the language of\n      the lexicon is the same as the language of the voice. </p>"
+                    }
+                },
+                "OutputFormat": {
+                    "target": "com.amazonaws.polly#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The format in which the returned output will be encoded. For audio\n      stream, this will be mp3, ogg_vorbis, ogg_opus, mu-law, a-law, or pcm. For speech marks, this will\n      be json. </p>"
+                    }
+                },
+                "SampleRate": {
+                    "target": "com.amazonaws.polly#SampleRate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio frequency specified in Hz.</p>\n         <p>The valid values for mp3 and ogg_vorbis are \"8000\", \"16000\", \"22050\",\n      and \"24000\". The default value for standard voices is \"22050\". The default\n      value for neural voices is \"24000\". The default value for long-form voices\n      is \"24000\". The default value for generative voices is \"24000\".</p>\n         <p>Valid values for pcm are \"8000\" and \"16000\" The default value is\n      \"16000\". </p>\n         <p>Valid value for ogg_opus is \"48000\". </p>\n         <p>Valid value for mu-law and a-law is \"8000\". </p>"
+                    }
+                },
+                "SpeechMarkTypes": {
+                    "target": "com.amazonaws.polly#SpeechMarkTypeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of speech marks returned for the input text.</p>"
+                    }
+                },
+                "TextType": {
+                    "target": "com.amazonaws.polly#TextType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether the input text is plain text or SSML. The default\n      value is plain text. </p>"
+                    }
+                },
+                "VoiceId": {
+                    "target": "com.amazonaws.polly#VoiceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Voice ID to use for the synthesis. </p>"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional language code for a synthesis task. This is only necessary if\n      using a bilingual voice, such as Aditi, which can be used for either\n      Indian English (en-IN) or Hindi (hi-IN). </p>\n         <p>If a bilingual voice is used and no language code is specified, Amazon Polly\n      uses the default language of the bilingual voice. The default language for\n      any voice is the one returned by the <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_DescribeVoices.html\">DescribeVoices</a> operation for the <code>LanguageCode</code>\n      parameter. For example, if no language code is specified, Aditi will use\n      Indian English rather than Hindi.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>SynthesisTask object that provides information about a speech\n      synthesis task.</p>"
+            }
+        },
+        "com.amazonaws.polly#SynthesisTaskNotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The Speech Synthesis task with requested Task ID cannot be\n      found.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#SynthesisTasks": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#SynthesisTask"
+            }
+        },
+        "com.amazonaws.polly#SynthesizeSpeech": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.polly#SynthesizeSpeechInput"
+            },
+            "output": {
+                "target": "com.amazonaws.polly#SynthesizeSpeechOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.polly#EngineNotSupportedException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidSampleRateException"
+                },
+                {
+                    "target": "com.amazonaws.polly#InvalidSsmlException"
+                },
+                {
+                    "target": "com.amazonaws.polly#LanguageNotSupportedException"
+                },
+                {
+                    "target": "com.amazonaws.polly#LexiconNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.polly#MarksNotSupportedForFormatException"
+                },
+                {
+                    "target": "com.amazonaws.polly#ServiceFailureException"
+                },
+                {
+                    "target": "com.amazonaws.polly#SsmlMarksNotSupportedForTextTypeException"
+                },
+                {
+                    "target": "com.amazonaws.polly#TextLengthExceededException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Synthesizes UTF-8 input, plain text or SSML, to a stream of bytes.\n      SSML input must be valid, well-formed SSML. Some alphabets might not be\n      available with all the voices (for example, Cyrillic might not be read at\n      all by English voices) unless phoneme mapping is used. For more\n      information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/how-text-to-speech-works.html\">How it Works</a>.</p>",
+                "smithy.api#examples": [
+                    {
+                        "title": "To synthesize speech",
+                        "documentation": "Synthesizes plain text or SSML into a file of human-like speech.",
+                        "input": {
+                            "LexiconNames": [
+                                "example"
+                            ],
+                            "OutputFormat": "mp3",
+                            "SampleRate": "8000",
+                            "Text": "All Gaul is divided into three parts",
+                            "TextType": "text",
+                            "VoiceId": "Joanna"
+                        },
+                        "output": {
+                            "AudioStream": "TEXT",
+                            "ContentType": "audio/mpeg",
+                            "RequestCharacters": 37
+                        }
+                    }
+                ],
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/v1/speech",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.polly#SynthesizeSpeechInput": {
+            "type": "structure",
+            "members": {
+                "Engine": {
+                    "target": "com.amazonaws.polly#Engine",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the engine (<code>standard</code>, <code>neural</code>,\n      <code>long-form</code>, or <code>generative</code>) for Amazon Polly\n      to use when processing input text for speech synthesis. Provide an engine\n      that is supported by the voice you select. If you don't provide an engine,\n      the standard engine is selected by default. If a chosen voice isn't supported\n      by the standard engine, this will result in an error. For information on\n      Amazon Polly voices and which voices are available for each engine, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/voicelist.html\">Available Voices</a>.</p>"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional language code for the Synthesize Speech request. This is only\n      necessary if using a bilingual voice, such as Aditi, which can be used for\n      either Indian English (en-IN) or Hindi (hi-IN). </p>\n         <p>If a bilingual voice is used and no language code is specified, Amazon Polly\n      uses the default language of the bilingual voice. The default language for\n      any voice is the one returned by the <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_DescribeVoices.html\">DescribeVoices</a> operation for the <code>LanguageCode</code>\n      parameter. For example, if no language code is specified, Aditi will use\n      Indian English rather than Hindi.</p>"
+                    }
+                },
+                "LexiconNames": {
+                    "target": "com.amazonaws.polly#LexiconNameList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of one or more pronunciation lexicon names you want the\n      service to apply during synthesis. Lexicons are applied only if the\n      language of the lexicon is the same as the language of the voice. For\n      information about storing lexicons, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_PutLexicon.html\">PutLexicon</a>.</p>"
+                    }
+                },
+                "OutputFormat": {
+                    "target": "com.amazonaws.polly#OutputFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The format in which the returned output will be encoded. For audio\n      stream, this will be mp3, ogg_vorbis, ogg_opus, mu-law, a-law or pcm. For speech marks, this will\n      be json. </p>\n         <p>When pcm is used, the content returned is audio/pcm in a signed\n      16-bit, 1 channel (mono), little-endian format. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SampleRate": {
+                    "target": "com.amazonaws.polly#SampleRate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The audio frequency specified in Hz.</p>\n         <p>The valid values for mp3 and ogg_vorbis are \"8000\", \"16000\", \"22050\", \"24000\", \"44100\" and \"48000\". The default value for standard voices is \"22050\". The default\n      value for neural voices is \"24000\". The default value for long-form voices\n      is \"24000\". The default value for generative voices is \"24000\".</p>\n         <p>Valid values for pcm are \"8000\" and \"16000\" The default value is\n      \"16000\". </p>\n         <p>Valid value for ogg_opus is \"48000\". </p>\n         <p>Valid value for mu-law and a-law is \"8000\". </p>"
+                    }
+                },
+                "SpeechMarkTypes": {
+                    "target": "com.amazonaws.polly#SpeechMarkTypeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of speech marks returned for the input text.</p>"
+                    }
+                },
+                "Text": {
+                    "target": "com.amazonaws.polly#Text",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Input text to synthesize. If you specify <code>ssml</code> as the\n        <code>TextType</code>, follow the SSML format for the input text.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TextType": {
+                    "target": "com.amazonaws.polly#TextType",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Specifies whether the input text is plain text or SSML. The\n      default value is plain text. For more information, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/ssml.html\">Using\n        SSML</a>.</p>"
+                    }
+                },
+                "VoiceId": {
+                    "target": "com.amazonaws.polly#VoiceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Voice ID to use for the synthesis. You can get a list of available\n      voice IDs by calling the <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_DescribeVoices.html\">DescribeVoices</a> operation. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.polly#SynthesizeSpeechOutput": {
+            "type": "structure",
+            "members": {
+                "AudioStream": {
+                    "target": "com.amazonaws.polly#AudioStream",
+                    "traits": {
+                        "smithy.api#default": "",
+                        "smithy.api#documentation": "<p> Stream containing the synthesized speech. </p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                },
+                "ContentType": {
+                    "target": "com.amazonaws.polly#ContentType",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Specifies the type audio stream. This should reflect the\n        <code>OutputFormat</code> parameter in your request. </p>\n         <ul>\n            <li>\n               <p> If you request <code>mp3</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/mpeg. </p>\n            </li>\n            <li>\n               <p> If you request <code>ogg_vorbis</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/ogg. </p>\n            </li>\n            <li>\n               <p> If you request <code>ogg_opus</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/ogg. </p>\n            </li>\n            <li>\n               <p> If you request <code>pcm</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/pcm in a signed 16-bit, 1 channel (mono), little-endian format.\n        </p>\n            </li>\n            <li>\n               <p> If you request <code>mu-law</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/mulaw.\n        </p>\n            </li>\n            <li>\n               <p> If you request <code>a-law</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          audio/alaw.\n        </p>\n            </li>\n            <li>\n               <p>If you request <code>json</code> as the\n            <code>OutputFormat</code>, the <code>ContentType</code> returned is\n          application/x-json-stream.</p>\n            </li>\n         </ul>\n         <p> </p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "RequestCharacters": {
+                    "target": "com.amazonaws.polly#RequestCharacters",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Number of characters synthesized.</p>",
+                        "smithy.api#httpHeader": "x-amzn-RequestCharacters"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.polly#TaskId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[a-zA-Z0-9_-]{1,100}$"
+            }
+        },
+        "com.amazonaws.polly#TaskStatus": {
+            "type": "enum",
+            "members": {
+                "SCHEDULED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "scheduled"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "inProgress"
+                    }
+                },
+                "COMPLETED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "completed"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "failed"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#TaskStatusReason": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#Text": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#TextEvent": {
+            "type": "structure",
+            "members": {
+                "Text": {
+                    "target": "com.amazonaws.polly#Text",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The text content to synthesize. If you specify <code>ssml</code> as the \n      <code>TextType</code>, follow the SSML format for the input text.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TextType": {
+                    "target": "com.amazonaws.polly#TextType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether the input text is plain text or SSML. Default: plain text.</p>"
+                    }
+                },
+                "FlushStreamConfiguration": {
+                    "target": "com.amazonaws.polly#FlushStreamConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for controlling when synthesized audio flushes to the output stream.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains text content to be synthesized into speech.</p>"
+            }
+        },
+        "com.amazonaws.polly#TextLengthExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The value of the \"Text\" parameter is longer than the accepted\n      limits. For the <code>SynthesizeSpeech</code> API, the limit for input\n      text is a maximum of 6000 characters total, of which no more than 3000 can\n      be billed characters. For the <code>StartSpeechSynthesisTask</code> API,\n      the maximum is 200,000 characters, of which no more than 100,000 can be\n      billed characters. SSML tags are not counted as billed\n      characters.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#TextType": {
+            "type": "enum",
+            "members": {
+                "SSML": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ssml"
+                    }
+                },
+                "TEXT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "text"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#AvailabilityErrorMessage"
+                },
+                "throttlingReasons": {
+                    "target": "com.amazonaws.polly#ThrottlingReasonList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of reasons explaining why the request was throttled.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "Throttling",
+                    "httpResponseCode": 400
+                },
+                "smithy.api#documentation": "<p>The request was denied because of request throttling.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#ThrottlingReason": {
+            "type": "structure",
+            "members": {
+                "reason": {
+                    "target": "com.amazonaws.polly#CoralAvailabilityThrottlingReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason code explaining why the request was throttled.</p>"
+                    }
+                },
+                "resource": {
+                    "target": "com.amazonaws.polly#CoralAvailabilityThrottledResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource that caused the throttling.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Provides information about a specific throttling reason.</p>"
+            }
+        },
+        "com.amazonaws.polly#ThrottlingReasonList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#ThrottlingReason"
+            }
+        },
+        "com.amazonaws.polly#UnsupportedPlsAlphabetException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The alphabet specified by the lexicon is not a supported alphabet.\n      Valid values are <code>x-sampa</code> and <code>ipa</code>.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#UnsupportedPlsLanguageException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The language specified in the lexicon is unsupported. For a list of\n      supported languages, see <a href=\"https://docs.aws.amazon.com/polly/latest/dg/API_LexiconAttributes.html\">Lexicon Attributes</a>.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#ValidationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.polly#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "reason": {
+                    "target": "com.amazonaws.polly#ValidationExceptionReason",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reason the request failed validation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "fields": {
+                    "target": "com.amazonaws.polly#ValidationExceptionFieldList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The fields that caused the validation error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input fails to satisfy the constraints specified by the service.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.polly#ValidationExceptionField": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.polly#ValidationExceptionFieldName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the field that failed validation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.polly#ValidationExceptionFieldMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A message describing why the field failed validation.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about a field that failed validation.</p>"
+            }
+        },
+        "com.amazonaws.polly#ValidationExceptionFieldList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#ValidationExceptionField"
+            }
+        },
+        "com.amazonaws.polly#ValidationExceptionFieldMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#ValidationExceptionFieldName": {
+            "type": "string"
+        },
+        "com.amazonaws.polly#ValidationExceptionReason": {
+            "type": "enum",
+            "members": {
+                "UNSUPPORTED_OPERATION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "unsupportedOperation"
+                    }
+                },
+                "FIELD_VALIDATION_FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "fieldValidationFailed"
+                    }
+                },
+                "OTHER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "other"
+                    }
+                },
+                "INVALID_INBOUND_EVENT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "invalidInboundEvent"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#Voice": {
+            "type": "structure",
+            "members": {
+                "Gender": {
+                    "target": "com.amazonaws.polly#Gender",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gender of the voice.</p>"
+                    }
+                },
+                "Id": {
+                    "target": "com.amazonaws.polly#VoiceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Amazon Polly assigned voice ID. This is the ID that you specify when\n      calling the <code>SynthesizeSpeech</code> operation.</p>"
+                    }
+                },
+                "LanguageCode": {
+                    "target": "com.amazonaws.polly#LanguageCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Language code of the voice.</p>"
+                    }
+                },
+                "LanguageName": {
+                    "target": "com.amazonaws.polly#LanguageName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Human readable name of the language in English.</p>"
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.polly#VoiceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the voice (for example, Salli, Kendra, etc.). This provides\n      a human readable voice name that you might display in your\n      application.</p>"
+                    }
+                },
+                "AdditionalLanguageCodes": {
+                    "target": "com.amazonaws.polly#LanguageCodeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Additional codes for languages available for the specified voice in\n      addition to its default language. </p>\n         <p>For example, the default language for Aditi is Indian English (en-IN)\n      because it was first used for that language. Since Aditi is bilingual and\n      fluent in both Indian English and Hindi, this parameter would show the\n      code <code>hi-IN</code>.</p>"
+                    }
+                },
+                "SupportedEngines": {
+                    "target": "com.amazonaws.polly#EngineList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies which engines (<code>standard</code>, <code>neural</code>,\n      <code>long-form</code> or <code>generative</code>) are supported by a given voice.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Description of the voice.</p>"
+            }
+        },
+        "com.amazonaws.polly#VoiceId": {
+            "type": "enum",
+            "members": {
+                "Aditi": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Aditi"
+                    }
+                },
+                "Amy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Amy"
+                    }
+                },
+                "Astrid": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Astrid"
+                    }
+                },
+                "Bianca": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Bianca"
+                    }
+                },
+                "Brian": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Brian"
+                    }
+                },
+                "Camila": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Camila"
+                    }
+                },
+                "Carla": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Carla"
+                    }
+                },
+                "Carmen": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Carmen"
+                    }
+                },
+                "Celine": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Celine"
+                    }
+                },
+                "Chantal": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Chantal"
+                    }
+                },
+                "Conchita": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Conchita"
+                    }
+                },
+                "Cristiano": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Cristiano"
+                    }
+                },
+                "Dora": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Dora"
+                    }
+                },
+                "Emma": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Emma"
+                    }
+                },
+                "Enrique": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enrique"
+                    }
+                },
+                "Ewa": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ewa"
+                    }
+                },
+                "Filiz": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Filiz"
+                    }
+                },
+                "Gabrielle": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Gabrielle"
+                    }
+                },
+                "Geraint": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Geraint"
+                    }
+                },
+                "Giorgio": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Giorgio"
+                    }
+                },
+                "Gwyneth": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Gwyneth"
+                    }
+                },
+                "Hans": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Hans"
+                    }
+                },
+                "Ines": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ines"
+                    }
+                },
+                "Ivy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ivy"
+                    }
+                },
+                "Jacek": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Jacek"
+                    }
+                },
+                "Jan": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Jan"
+                    }
+                },
+                "Joanna": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Joanna"
+                    }
+                },
+                "Joey": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Joey"
+                    }
+                },
+                "Justin": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Justin"
+                    }
+                },
+                "Karl": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Karl"
+                    }
+                },
+                "Kendra": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kendra"
+                    }
+                },
+                "Kevin": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kevin"
+                    }
+                },
+                "Kimberly": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kimberly"
+                    }
+                },
+                "Lea": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lea"
+                    }
+                },
+                "Liv": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Liv"
+                    }
+                },
+                "Lotte": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lotte"
+                    }
+                },
+                "Lucia": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lucia"
+                    }
+                },
+                "Lupe": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lupe"
+                    }
+                },
+                "Mads": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Mads"
+                    }
+                },
+                "Maja": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Maja"
+                    }
+                },
+                "Marlene": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Marlene"
+                    }
+                },
+                "Mathieu": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Mathieu"
+                    }
+                },
+                "Matthew": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Matthew"
+                    }
+                },
+                "Maxim": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Maxim"
+                    }
+                },
+                "Mia": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Mia"
+                    }
+                },
+                "Miguel": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Miguel"
+                    }
+                },
+                "Mizuki": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Mizuki"
+                    }
+                },
+                "Naja": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Naja"
+                    }
+                },
+                "Nicole": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Nicole"
+                    }
+                },
+                "Olivia": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Olivia"
+                    }
+                },
+                "Penelope": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Penelope"
+                    }
+                },
+                "Raveena": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Raveena"
+                    }
+                },
+                "Ricardo": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ricardo"
+                    }
+                },
+                "Ruben": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ruben"
+                    }
+                },
+                "Russell": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Russell"
+                    }
+                },
+                "Salli": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Salli"
+                    }
+                },
+                "Seoyeon": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Seoyeon"
+                    }
+                },
+                "Takumi": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Takumi"
+                    }
+                },
+                "Tatyana": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Tatyana"
+                    }
+                },
+                "Vicki": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Vicki"
+                    }
+                },
+                "Vitoria": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Vitoria"
+                    }
+                },
+                "Zeina": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Zeina"
+                    }
+                },
+                "Zhiyu": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Zhiyu"
+                    }
+                },
+                "Aria": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Aria"
+                    }
+                },
+                "Ayanda": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ayanda"
+                    }
+                },
+                "Arlet": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Arlet"
+                    }
+                },
+                "Hannah": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Hannah"
+                    }
+                },
+                "Arthur": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Arthur"
+                    }
+                },
+                "Daniel": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Daniel"
+                    }
+                },
+                "Liam": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Liam"
+                    }
+                },
+                "Pedro": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Pedro"
+                    }
+                },
+                "Kajal": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kajal"
+                    }
+                },
+                "Hiujin": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Hiujin"
+                    }
+                },
+                "Laura": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Laura"
+                    }
+                },
+                "Elin": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Elin"
+                    }
+                },
+                "Ida": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ida"
+                    }
+                },
+                "Suvi": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Suvi"
+                    }
+                },
+                "Ola": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ola"
+                    }
+                },
+                "Hala": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Hala"
+                    }
+                },
+                "Andres": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Andres"
+                    }
+                },
+                "Sergio": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Sergio"
+                    }
+                },
+                "Remi": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Remi"
+                    }
+                },
+                "Adriano": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Adriano"
+                    }
+                },
+                "Thiago": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Thiago"
+                    }
+                },
+                "Ruth": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ruth"
+                    }
+                },
+                "Stephen": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Stephen"
+                    }
+                },
+                "Kazuha": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kazuha"
+                    }
+                },
+                "Tomoko": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Tomoko"
+                    }
+                },
+                "Niamh": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Niamh"
+                    }
+                },
+                "Sofie": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Sofie"
+                    }
+                },
+                "Lisa": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lisa"
+                    }
+                },
+                "Isabelle": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Isabelle"
+                    }
+                },
+                "Zayd": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Zayd"
+                    }
+                },
+                "Danielle": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Danielle"
+                    }
+                },
+                "Gregory": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Gregory"
+                    }
+                },
+                "Burcu": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Burcu"
+                    }
+                },
+                "Jitka": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Jitka"
+                    }
+                },
+                "Sabrina": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Sabrina"
+                    }
+                },
+                "Jasmine": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Jasmine"
+                    }
+                },
+                "Jihye": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Jihye"
+                    }
+                },
+                "Ambre": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ambre"
+                    }
+                },
+                "Beatrice": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Beatrice"
+                    }
+                },
+                "Florian": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Florian"
+                    }
+                },
+                "Lennart": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lennart"
+                    }
+                },
+                "Lorenzo": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Lorenzo"
+                    }
+                },
+                "Tiffany": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Tiffany"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.polly#VoiceList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.polly#Voice"
+            }
+        },
+        "com.amazonaws.polly#VoiceName": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the Smithy model for the Amazon Polly service. This will enable us to automatically generate and publish the `aws-sdk-polly` client in our next release. 

## Testing

Using the latest version of the smithy-python code generator, I was able to build the polly service and make successful service calls.

TODO: Add more details

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
