### PR TITLE
Add new clients to meta package

### DIFF
--- a/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-2419cea0baf7431781efcd7bc75ad618.json
+++ b/clients/aws-sdk-python/.changes/next-release/aws-sdk-python-dependency-2419cea0baf7431781efcd7bc75ad618.json
@@ -1,0 +1,4 @@
+{
+  "type": "dependency",
+  "description": "Add support for the following clients:\n  * `aws-sdk-bedrock-data-automation-runtime`\n  * `aws-sdk-cloudtrail`\n  * `aws-sdk-cognito-identity`\n  * `aws-sdk-dynamodb`\n  * `aws-sdk-secrets-manager`\n  * `aws-sdk-sqs`"
+}

--- a/clients/aws-sdk-python/pyproject.toml
+++ b/clients/aws-sdk-python/pyproject.toml
@@ -29,15 +29,21 @@ bedrock_agent_runtime = ["aws_sdk_bedrock_agent_runtime~=0.10.0"]
 bedrock_agentcore = ["aws_sdk_bedrock_agentcore~=0.10.0"]
 bedrock_agentcore_control = ["aws_sdk_bedrock_agentcore_control~=0.10.0"]
 bedrock_data_automation = ["aws_sdk_bedrock_data_automation~=0.10.0"]
+bedrock_data_automation_runtime = ["aws_sdk_bedrock_data_automation_runtime~=0.10.0"]
 bedrock_runtime = ["aws_sdk_bedrock_runtime~=0.10.0"]
+cloudtrail = ["aws_sdk_cloudtrail~=0.10.0"]
+cognito_identity = ["aws_sdk_cognito_identity~=0.10.0"]
 connecthealth = ["aws_sdk_connecthealth~=0.10.0"]
+dynamodb = ["aws_sdk_dynamodb~=0.10.0"]
 guardduty = ["aws_sdk_guardduty~=0.10.0"]
 lambda = ["aws_sdk_lambda~=0.10.0"]
 lex_runtime_v2 = ["aws_sdk_lex_runtime_v2~=0.10.0"]
 polly = ["aws_sdk_polly~=0.10.0"]
 qbusiness = ["aws_sdk_qbusiness~=0.10.0"]
 sagemaker_runtime_http2 = ["aws_sdk_sagemaker_runtime_http2~=0.10.0"]
+secrets_manager = ["aws_sdk_secrets_manager~=0.10.0"]
 sns = ["aws_sdk_sns~=0.10.0"]
+sqs = ["aws_sdk_sqs~=0.10.0"]
 sts = ["aws_sdk_sts~=0.10.0"]
 transcribe_streaming = ["aws_sdk_transcribe_streaming~=0.10.0"]
 
@@ -49,15 +55,21 @@ all = [
     "aws_sdk_python[bedrock_agentcore]",
     "aws_sdk_python[bedrock_agentcore_control]",
     "aws_sdk_python[bedrock_data_automation]",
+    "aws_sdk_python[bedrock_data_automation_runtime]",
     "aws_sdk_python[bedrock_runtime]",
+    "aws_sdk_python[cloudtrail]",
+    "aws_sdk_python[cognito_identity]",
     "aws_sdk_python[connecthealth]",
+    "aws_sdk_python[dynamodb]",
     "aws_sdk_python[guardduty]",
     "aws_sdk_python[lambda]",
     "aws_sdk_python[lex_runtime_v2]",
     "aws_sdk_python[polly]",
     "aws_sdk_python[qbusiness]",
     "aws_sdk_python[sagemaker_runtime_http2]",
+    "aws_sdk_python[secrets_manager]",
     "aws_sdk_python[sns]",
+    "aws_sdk_python[sqs]",
     "aws_sdk_python[sts]",
     "aws_sdk_python[transcribe_streaming]",
 ]


### PR DESCRIPTION
> [!NOTE]
> We stilll need to implement a permanent fix for this at our infrastructure layer. Will manually update instead for now. Our automation does know how to bump known clients, but not add new ones.

### Description
This PR adds optional dependencies for the 6 new services released on 2026-08-29 to the `aws-sdk-python` meta-package.

These clients are available as version `0.10.0` packages but were not installable through the meta-package’s service-specific or aggregate extras. The meta package expose optional dependency groups to allow for users to more easily install multiple compatible services together (e.g., `aws-sdk-python[bedrock-runtime, polly]`.

Past PR for a similar change:  https://github.com/aws/aws-sdk-python/pull/76

### Summary
- Add extras for:
  - `bedrock_data_automation_runtime`
  - `cloudtrail`
  - `cognito_identity`
  - `dynamodb`
  - `secrets_manager`
  - `sqs`
- Include the new extras in `aws_sdk_python[all]`.
- Add a `dependency` changelog entry.

### Testing
Verified that the generated wheel metadata contains the new dependencies and correctly expands the `all` extra.

```
🏡 …/update-meta-package/clients/aws-sdk-python
> uv venv
Using CPython 3.14.2
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate

🏡 …/update-meta-package/clients/aws-sdk-python
> source .venv/bin/activate

🏡 …/update-meta-package/clients/aws-sdk-python (aws-sdk-python)
> uv build .
Building source distribution...
Building wheel from source distribution...
Successfully built dist/aws_sdk_python-0.10.0.tar.gz
Successfully built dist/aws_sdk_python-0.10.0-py3-none-any.whl

🏡 …/update-meta-package/clients/aws-sdk-python (aws-sdk-python)
> uv pip install "aws-sdk-python[all]" --find-links=dist/
Resolved 43 packages in 609ms
Prepared 43 packages in 246ms
Installed 43 packages in 4.75s
 + aiohappyeyeballs==2.7.1
 + aiohttp==3.14.3
 + aiosignal==1.4.0
 + attrs==26.1.0
 + aws-sdk-api-gateway==0.10.0
 + aws-sdk-bedrock==0.10.0
 + aws-sdk-bedrock-agent==0.10.0
 + aws-sdk-bedrock-agent-runtime==0.10.0
 + aws-sdk-bedrock-agentcore==0.10.0
 + aws-sdk-bedrock-agentcore-control==0.10.0
 + aws-sdk-bedrock-data-automation==0.10.0
 + aws-sdk-bedrock-data-automation-runtime==0.10.0
 + aws-sdk-bedrock-runtime==0.10.0
 + aws-sdk-cloudtrail==0.10.0
 + aws-sdk-cognito-identity==0.10.0
 + aws-sdk-connecthealth==0.10.0
 + aws-sdk-dynamodb==0.10.0
 + aws-sdk-guardduty==0.10.0
 + aws-sdk-lambda==0.10.0
 + aws-sdk-lex-runtime-v2==0.10.0
 + aws-sdk-polly==0.10.0
 + aws-sdk-python==0.10.0
 + aws-sdk-qbusiness==0.10.0
 + aws-sdk-sagemaker-runtime-http2==0.10.0
 + aws-sdk-secrets-manager==0.10.0
 + aws-sdk-signers==0.3.0
 + aws-sdk-sns==0.10.0
 + aws-sdk-sqs==0.10.0
 + aws-sdk-sts==0.10.0
 + aws-sdk-transcribe-streaming==0.10.0
 + awscrt==0.32.2
 + frozenlist==1.8.0
 + idna==3.19
 + ijson==3.5.1
 + multidict==6.7.1
 + propcache==0.5.2
 + smithy-aws-core==0.10.0
 + smithy-aws-event-stream==0.3.0
 + smithy-core==0.8.1
 + smithy-http==0.4.4
 + smithy-json==0.3.0
 + smithy-xml==0.1.0
 + yarl==1.24.5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
