### PR TITLE
Improve the API reference landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 The AWS SDK for Python provides asynchronous clients for supported AWS services.
 Each service has its own package.
 
-!!! warning "Developer preview: Not for production use"
+!!! warning "Developer Preview: Not for production use"
 
     Use this SDK for evaluation and pre-production testing. Interfaces and
     behavior may change before general availability. Use
@@ -29,33 +29,58 @@ The code generator builds each client from its service's
 
 ## Install a client
 
-The clients require Python 3.12 or later.
+The clients require Python 3.12 or later. Follow the
+[uv installation guide](https://docs.astral.sh/uv/getting-started/installation/),
+then create and activate a virtual environment:
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+```
 
 === "One client"
 
     Install the Amazon DynamoDB client from its service package:
 
     ```bash
-    pip install aws-sdk-dynamodb
+    uv pip install aws-sdk-dynamodb
     ```
 
 === "Several clients"
 
-    The `aws-sdk-python` meta-package keeps its client dependencies on
-    compatible versions. Select the clients you need through package extras:
+    Use the `aws-sdk-python` meta-package to install several clients at
+    compatible versions. Select clients with package extras:
 
     ```bash
-    pip install "aws-sdk-python[bedrock_runtime,sts]"
+    uv pip install "aws-sdk-python[bedrock-runtime,sts]"
     ```
 
-The [available clients](clients/index.md) page lists every service package.
+See [available clients](clients/index.md) for a list of service packages.
 
 ## List DynamoDB tables
 
-After you [configure AWS credentials](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)
-and grant `dynamodb:ListTables` permission, use the
-[Amazon DynamoDB client](clients/dynamodb/index.md) to list up to ten tables in
-`us-east-1`:
+Before running the example, grant an identity `dynamodb:ListTables` permission
+and configure AWS credentials. The default credential chain checks these
+built-in sources:
+
+- Environment variables such as `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`
+- Shared AWS config and credentials files, including `credential_process`
+
+Other supported providers come from `aws-credentials-*` packages. Install and
+configure the package for your environment:
+
+- `aws-credentials-sts` for profile-based AssumeRole
+- `aws-credentials-http` for Amazon ECS or Amazon EKS container credentials
+- `aws-credentials-imds` for Amazon EC2 instance metadata
+
+The SDK detects installed provider packages and adds them to the chain
+automatically. You do not need to pass a credential resolver or change the
+client code. The IAM Identity Center (SSO) credential provider and the login
+credentials provider are not yet supported.
+
+Use the [Amazon DynamoDB client](clients/dynamodb/index.md) to list up to ten
+tables in `us-east-1`:
 
 ```python
 import asyncio
@@ -67,19 +92,20 @@ from aws_sdk_dynamodb.models import ListTablesInput
 
 async def main():
     config = await AsyncDynamoDBConfig.resolve(region="us-east-1")
-    client = AsyncDynamoDBClient(config=config)
 
-    response = await client.list_tables(input=ListTablesInput(limit=10))
-    for table in response.table_names or []:
-        print(table)
+    async with AsyncDynamoDBClient(config=config) as client:
+        response = await client.list_tables(input=ListTablesInput(limit=10))
+        for table in response.table_names:
+            print(table)
 
 
 asyncio.run(main())
 ```
 
-`AsyncDynamoDBConfig.resolve()` loads credentials and other shared settings
-from the standard AWS configuration sources. The `region` argument overrides
-the configured region for this client.
+`AsyncDynamoDBConfig.resolve()` loads shared settings such as retry
+configuration. Here, the `region` argument overrides a region set in the
+environment or shared config. The client resolves credentials through the
+default chain when it sends the request.
 
 ## Documentation and support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,59 +1,64 @@
 # AWS SDK for Python
 
-Async-first clients for AWS services, distributed as one lightweight package
-per service.
+The AWS SDK for Python provides async-first clients for select AWS services.
+Each client is distributed as a lightweight, per-service package.
 
-Unlike [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html),
-these clients are built from the ground up on Python's `async`/`await`. They
-target select AWS services that benefit most from asynchronous I/O, such as
-streaming and real-time inference APIs. Each client is generated from its
-service's [Smithy](https://smithy.io/) model and is fully type-annotated, so
-your editor can autocomplete operations, inputs, and response shapes without
-extra stub packages.
+!!! warning "Developer Preview: Not for production use"
 
-!!! warning "Developer Preview — not for production use"
+    This SDK is intended for evaluation and testing in pre-production
+    environments. APIs and behavior may change before general availability. For
+    production workloads, use
+    [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html).
 
-    This SDK is in Developer Preview and is intended for evaluation and testing
-    in pre-production environments only. APIs and behavior may change before
-    general availability. For production workloads, use
-    [Boto3](https://github.com/boto/boto3) — the generally available AWS SDK
-    for Python with full coverage of all AWS services.
+[Browse clients](clients/index.md){ .md-button .md-button--primary }
+[View source](https://github.com/aws/aws-sdk-python){ .md-button }
 
-## Highlights
+## What it provides
 
-- **Async first**: Every operation is a coroutine, designed for
-  `asyncio`-based applications.
-- **Per-service packages**: Install only the clients you need. Each package is
-  versioned and released independently.
-- **Fully typed**: Generated dataclass models and annotated signatures for
-  every operation.
+Use these clients when your application needs non-blocking access to supported
+AWS services, including services with streaming and real-time APIs. The clients
+are built on Python's `async`/`await` and generated from
+[Smithy](https://smithy.io/) service models.
+
+- **Async operations**: Call AWS services without blocking an `asyncio`
+  application.
+- **Per-service packages**: Install only the clients your application needs.
+- **Type annotations**: Get editor completion and type checking for operations,
+  input models, and response models without separate stub packages.
 - **Streaming support**: First-class support for event streams and
   bidirectional streaming operations.
 
-## Installation
+## Packages
 
-Each service client is its own package on PyPI and requires Python 3.12 or
-later. Create and activate a virtual environment, then install the clients you
-need:
+The clients require Python 3.12 or later. Choose a per-service package or use
+the `aws-sdk-python` meta-package for a compatible set of clients.
 
-```bash
-pip install aws-sdk-dynamodb
-```
+=== "One service"
 
-If your application uses several services, you can instead install the
-`aws-sdk-python` meta-package and select clients as extras. It coordinates
-compatible client versions through its own `MAJOR.MINOR` version:
+    Install only the client you need. For example, install the Amazon DynamoDB
+    client with:
 
-```bash
-pip install "aws-sdk-python[bedrock_runtime,sts]"
-```
+    ```bash
+    pip install aws-sdk-dynamodb
+    ```
+
+=== "Multiple services"
+
+    Select clients as extras of the `aws-sdk-python` meta-package. The
+    meta-package selects compatible client versions for you:
+
+    ```bash
+    pip install "aws-sdk-python[bedrock_runtime,sts]"
+    ```
 
 See [Available Clients](clients/index.md) for the full list of service
 packages.
 
-## Quick example
+## Example
 
-List your DynamoDB tables with the Amazon DynamoDB client:
+After you [configure AWS credentials](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)
+and grant permission to call `dynamodb:ListTables`, you can list your DynamoDB
+tables:
 
 ```python
 import asyncio
@@ -65,44 +70,23 @@ from aws_sdk_dynamodb.models import ListTablesInput
 
 async def main():
     config = await AsyncDynamoDBConfig.resolve(region="us-east-1")
+    client = AsyncDynamoDBClient(config=config)
 
-    async with AsyncDynamoDBClient(config=config) as client:
-        response = await client.list_tables(input=ListTablesInput(limit=10))
-        for table in response.table_names or []:
-            print(table)
+    response = await client.list_tables(input=ListTablesInput(limit=10))
+    for table in response.table_names or []:
+        print(table)
 
 
 asyncio.run(main())
 ```
 
-## Explore
+The configuration resolver can load credentials and other shared settings from
+the standard AWS configuration sources. Each client operation accepts a typed
+input model and returns a typed response model.
 
-<div class="grid cards" markdown>
+## Next steps
 
-- **Available Clients**
-
-    ---
-
-    Browse the full API reference for every service client in the SDK.
-
-    [:octicons-arrow-right-24: Available Clients](clients/index.md)
-
-- **Contributing**
-
-    ---
-
-    Learn how to report issues, propose changes, and set up a development
-    environment.
-
-    [:octicons-arrow-right-24: Contributing](contributing.md)
-
-- **Feedback**
-
-    ---
-
-    We welcome all feedback while we develop, and we use it to drive the
-    direction of the SDK. Tell us what you like, dislike, or want to see next.
-
-    [:octicons-arrow-right-24: Open a GitHub issue](https://github.com/aws/aws-sdk-python/issues/new/choose)
-
-</div>
+- Browse the [available clients and API reference](clients/index.md).
+- Learn how to [contribute to the SDK](contributing.md).
+- [Open a GitHub issue](https://github.com/aws/aws-sdk-python/issues/new/choose)
+  to report a problem or share feedback.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,120 @@
 # AWS SDK for Python
 
---8<-- "README.md:2"
+Async-first clients for AWS services, distributed as one lightweight package
+per service.
+
+Unlike [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html),
+these clients are built from the ground up on Python's `async`/`await`. They
+target select AWS services that benefit most from asynchronous I/O, such as
+streaming and real-time inference APIs. Each client is generated from its
+service's [Smithy](https://smithy.io/) model and is fully type-annotated, so
+your editor can autocomplete operations, inputs, and response shapes without
+extra stub packages.
+
+!!! warning "Developer Preview — not for production use"
+
+    This SDK is in Developer Preview and is intended for evaluation and testing
+    in pre-production environments only. APIs and behavior may change before
+    general availability. For production workloads, use
+    [Boto3](https://github.com/boto/boto3) — the generally available AWS SDK
+    for Python with full coverage of all AWS services.
+
+## Highlights
+
+- **Async first**: Every operation is a coroutine, designed for
+  `asyncio`-based applications.
+- **Per-service packages**: Install only the clients you need. Each package is
+  versioned and released independently.
+- **Fully typed**: Generated dataclass models and annotated signatures for
+  every operation.
+- **Streaming support**: First-class support for event streams and
+  bidirectional streaming operations.
+
+## Installation
+
+Each service client is its own package on PyPI and requires Python 3.12 or
+later. Create and activate a virtual environment and then install the clients
+you need:
+
+```bash
+pip install aws-sdk-bedrock-runtime
+```
+
+See [Available Clients](clients/index.md) for the full list of service
+packages.
+
+## Quick example
+
+Send a message to a model with the Amazon Bedrock Runtime client:
+
+```python
+import asyncio
+
+from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, ConverseInput
+from aws_sdk_bedrock_runtime.config import Config
+from aws_sdk_bedrock_runtime.models import ContentBlockText, Message
+from smithy_aws_core.identity import EnvironmentCredentialsResolver
+
+
+async def main():
+    client = BedrockRuntimeClient(
+        config=Config(
+            region="us-east-1",
+            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+        )
+    )
+
+    response = await client.converse(
+        ConverseInput(
+            model_id="global.anthropic.claude-opus-4-8",  # (1)!
+            messages=[
+                Message(
+                    role="user",
+                    content=[ContentBlockText(value="Tell me a fun fact about Python.")],
+                )
+            ],
+        )
+    )
+
+    print(response.output.value.content[0].value)
+
+
+asyncio.run(main())
+```
+
+1.  This model may not be the latest available and could be deprecated in the
+    future. See [Models at a glance](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html)
+    in the Amazon Bedrock User Guide for the current list of models and their
+    IDs.
+
+## Explore
+
+<div class="grid cards" markdown>
+
+- **Available Clients**
+
+    ---
+
+    Browse the full API reference for every service client in the SDK.
+
+    [:octicons-arrow-right-24: Available Clients](clients/index.md)
+
+- **Contributing**
+
+    ---
+
+    Learn how to report issues, propose changes, and set up a development
+    environment.
+
+    [:octicons-arrow-right-24: Contributing](contributing.md)
+
+- **Feedback**
+
+    ---
+
+    We welcome all feedback while we develop, and we use it to drive the
+    direction of the SDK. Tell us what you like, dislike, or want to see next.
+
+    [:octicons-arrow-right-24: Open a GitHub issue](https://github.com/aws/aws-sdk-python/issues/new/choose)
+
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,11 +33,19 @@ extra stub packages.
 ## Installation
 
 Each service client is its own package on PyPI and requires Python 3.12 or
-later. Create and activate a virtual environment and then install the clients
-you need:
+later. Create and activate a virtual environment, then install the clients you
+need:
 
 ```bash
-pip install aws-sdk-bedrock-runtime
+pip install aws-sdk-dynamodb
+```
+
+If your application uses several services, you can instead install the
+`aws-sdk-python` meta-package and select clients as extras. It coordinates
+compatible client versions through its own `MAJOR.MINOR` version:
+
+```bash
+pip install "aws-sdk-python[bedrock_runtime,sts]"
 ```
 
 See [Available Clients](clients/index.md) for the full list of service
@@ -45,47 +53,27 @@ packages.
 
 ## Quick example
 
-Send a message to a model with the Amazon Bedrock Runtime client:
+List your DynamoDB tables with the Amazon DynamoDB client:
 
 ```python
 import asyncio
 
-from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, ConverseInput
-from aws_sdk_bedrock_runtime.config import Config
-from aws_sdk_bedrock_runtime.models import ContentBlockText, Message
-from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from aws_sdk_dynamodb.client import AsyncDynamoDBClient
+from aws_sdk_dynamodb.config import AsyncDynamoDBConfig
+from aws_sdk_dynamodb.models import ListTablesInput
 
 
 async def main():
-    client = BedrockRuntimeClient(
-        config=Config(
-            region="us-east-1",
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
-    )
+    config = await AsyncDynamoDBConfig.resolve(region="us-east-1")
 
-    response = await client.converse(
-        ConverseInput(
-            model_id="global.anthropic.claude-opus-4-8",  # (1)!
-            messages=[
-                Message(
-                    role="user",
-                    content=[ContentBlockText(value="Tell me a fun fact about Python.")],
-                )
-            ],
-        )
-    )
-
-    print(response.output.value.content[0].value)
+    async with AsyncDynamoDBClient(config=config) as client:
+        response = await client.list_tables(input=ListTablesInput(limit=10))
+        for table in response.table_names or []:
+            print(table)
 
 
 asyncio.run(main())
 ```
-
-1.  This model may not be the latest available and could be deprecated in the
-    future. See [Models at a glance](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html)
-    in the Amazon Bedrock User Guide for the current list of models and their
-    IDs.
 
 ## Explore
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ async def main():
 
     async with AsyncDynamoDBClient(config=config) as client:
         response = await client.list_tables(input=ListTablesInput(limit=10))
-        for table in response.table_names:
+        for table in response.table_names or []:
             print(table)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,64 +1,61 @@
 # AWS SDK for Python
 
-The AWS SDK for Python provides async-first clients for select AWS services.
-Each client is distributed as a lightweight, per-service package.
+The AWS SDK for Python provides asynchronous clients for supported AWS services.
+Each service has its own package.
 
-!!! warning "Developer Preview: Not for production use"
+!!! warning "Developer preview: Not for production use"
 
-    This SDK is intended for evaluation and testing in pre-production
-    environments. APIs and behavior may change before general availability. For
-    production workloads, use
-    [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html).
+    Use this SDK for evaluation and pre-production testing. Interfaces and
+    behavior may change before general availability. Use
+    [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html)
+    for production workloads.
 
 [Browse clients](clients/index.md){ .md-button .md-button--primary }
 [View source](https://github.com/aws/aws-sdk-python){ .md-button }
 
-## What it provides
+## Features
 
-Use these clients when your application needs non-blocking access to supported
-AWS services, including services with streaming and real-time APIs. The clients
-are built on Python's `async`/`await` and generated from
-[Smithy](https://smithy.io/) service models.
+- **Async operations.** Every service operation is an `async` method that works
+  with `asyncio`.
+- **Per-service packages.** Install only the clients your application uses.
+- **Type annotations.** Operations, input models, and response models include
+  type annotations, so editors and type checkers do not need separate stub
+  packages.
+- **Streaming support.** Clients for streaming services support event streams
+  and bidirectional streaming.
 
-- **Async operations**: Call AWS services without blocking an `asyncio`
-  application.
-- **Per-service packages**: Install only the clients your application needs.
-- **Type annotations**: Get editor completion and type checking for operations,
-  input models, and response models without separate stub packages.
-- **Streaming support**: First-class support for event streams and
-  bidirectional streaming operations.
+The code generator builds each client from its service's
+[Smithy](https://smithy.io/) model.
 
-## Packages
+## Install a client
 
-The clients require Python 3.12 or later. Choose a per-service package or use
-the `aws-sdk-python` meta-package for a compatible set of clients.
+The clients require Python 3.12 or later.
 
-=== "One service"
+=== "One client"
 
-    Install only the client you need. For example, install the Amazon DynamoDB
-    client with:
+    Install the Amazon DynamoDB client from its service package:
 
     ```bash
     pip install aws-sdk-dynamodb
     ```
 
-=== "Multiple services"
+=== "Several clients"
 
-    Select clients as extras of the `aws-sdk-python` meta-package. The
-    meta-package selects compatible client versions for you:
+    The `aws-sdk-python` meta-package keeps its client dependencies on
+    compatible versions. Select the clients you need through package extras:
 
     ```bash
     pip install "aws-sdk-python[bedrock_runtime,sts]"
     ```
 
-See [Available Clients](clients/index.md) for the full list of service
-packages.
+The [available clients](clients/index.md) page lists every service package.
 
-## Example
+## List DynamoDB tables
 
 After you [configure AWS credentials](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)
-and grant permission to call `dynamodb:ListTables`, you can list your DynamoDB
-tables:
+and grant `dynamodb:ListTables` permission, use the
+[Amazon DynamoDB client](clients/dynamodb/index.md) to list up to ten tables in
+`us-east-1`:
 
 ```python
 import asyncio
@@ -80,13 +77,12 @@ async def main():
 asyncio.run(main())
 ```
 
-The configuration resolver can load credentials and other shared settings from
-the standard AWS configuration sources. Each client operation accepts a typed
-input model and returns a typed response model.
+`AsyncDynamoDBConfig.resolve()` loads credentials and other shared settings
+from the standard AWS configuration sources. The `region` argument overrides
+the configured region for this client.
 
-## Next steps
+## Documentation and support
 
-- Browse the [available clients and API reference](clients/index.md).
-- Learn how to [contribute to the SDK](contributing.md).
-- [Open a GitHub issue](https://github.com/aws/aws-sdk-python/issues/new/choose)
-  to report a problem or share feedback.
+- [Browse client API references](clients/index.md)
+- [Contribute to the SDK](contributing.md)
+- [Report a bug or request a feature](https://github.com/aws/aws-sdk-python/issues/new/choose)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -16,11 +16,13 @@ p:has(span.breadcrumb) {
 /* Keep the Developer Preview announcement prominent across the docs site. */
 .md-banner {
   background-color: #ffe0a3;
+  border-bottom: 1px solid #d98b00;
   color: #291b00;
 }
 
 [data-md-color-scheme="slate"] .md-banner {
   background-color: #332407;
+  border-bottom-color: #8f650b;
   color: #fff4d6;
 }
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,3 +12,29 @@ p:has(span.breadcrumb) {
 [data-md-color-scheme="default"] .md-header__button.md-logo img {
   content: url('../assets/aws-logo-dark.svg');
 }
+
+/* Keep the Developer Preview announcement prominent across the docs site. */
+.md-banner {
+  background-color: #ffe0a3;
+  color: #291b00;
+}
+
+[data-md-color-scheme="slate"] .md-banner {
+  background-color: #332407;
+  color: #fff4d6;
+}
+
+.md-banner__inner {
+  font-size: 0.72rem;
+}
+
+.md-banner__inner strong,
+.md-banner__inner a {
+  font-weight: 700;
+}
+
+.md-banner__inner a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.1em;
+}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <strong>Developer Preview:</strong>
+  This SDK is not for production use, and its APIs and behavior may change.
+  For production workloads, use
+  <a href="https://boto3.amazonaws.com/v1/documentation/api/latest/index.html">Boto3</a>.
+{% endblock %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,15 +30,21 @@ nav = [
     { "Bedrock AgentCore" = "clients/bedrock-agentcore/index.md" },
     { "Bedrock AgentCore Control" = "clients/bedrock-agentcore-control/index.md" },
     { "Bedrock Data Automation" = "clients/bedrock-data-automation/index.md" },
+    { "Bedrock Data Automation Runtime" = "clients/bedrock-data-automation-runtime/index.md" },
     { "Bedrock Runtime" = "clients/bedrock-runtime/index.md" },
+    { "CloudTrail" = "clients/cloudtrail/index.md" },
+    { "Cognito Identity" = "clients/cognito-identity/index.md" },
     { "ConnectHealth" = "clients/connecthealth/index.md" },
+    { "DynamoDB" = "clients/dynamodb/index.md" },
     { "GuardDuty" = "clients/guardduty/index.md" },
     { "Lambda" = "clients/lambda/index.md" },
     { "Lex Runtime V2" = "clients/lex-runtime-v2/index.md" },
     { "Polly" = "clients/polly/index.md" },
     { "QBusiness" = "clients/qbusiness/index.md" },
     { "SageMaker Runtime HTTP2" = "clients/sagemaker-runtime-http2/index.md" },
+    { "Secrets Manager" = "clients/secrets-manager/index.md" },
     { "SNS" = "clients/sns/index.md" },
+    { "SQS" = "clients/sqs/index.md" },
     { "STS" = "clients/sts/index.md" },
     { "Transcribe Streaming" = "clients/transcribe-streaming/index.md" },
   ] },
@@ -55,6 +61,7 @@ extra_javascript = [{ path = "javascript/nav-expand.js", defer = true }]
 # ----------------------------------------------------------------------------
 [project.theme]
 language = "en"
+custom_dir = "overrides"
 
 features = [
     # Zensical includes an announcement bar. This feature allows users to


### PR DESCRIPTION
## Overview

The API reference currently inherits its landing page from the repository README, which leaves readers without a clear introduction to the SDK or path into the reference documentation.

This PR replaces it with a purpose-built overview and adds a dismissible Developer Preview notice across the docs. The banner ensures that users entering through deep links still see the production-use guidance.


## Testing / Preview

- `make docs-install`
- `make docs`
- `make docs-serve`

<img width="1512" height="741" alt="Screenshot 2026-08-21 at 12 08 01 AM" src="https://github.com/user-attachments/assets/5ce9f098-fb11-4529-826a-10c9f54392b1" />

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
