### PR TITLE
Update integration tests for AIOHTTP default and async client lifecycle

### DIFF
--- a/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/__init__.py
@@ -4,9 +4,11 @@
 
 from pathlib import Path
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient
+from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient
 from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
 
 MODEL_ID = "global.amazon.nova-2-lite-v1:0"
@@ -15,12 +17,17 @@ MESSAGE = "Who created the Python programming language?"
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.pcm"
 
 
-async def create_bedrock_client(region: str) -> BedrockRuntimeClient:
-    """Helper to create a BedrockRuntimeClient for a given region."""
-    return BedrockRuntimeClient(
-        config=await AsyncBedrockRuntimeConfig.resolve(
-            endpoint_uri=f"https://bedrock-runtime.{region}.amazonaws.com",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
+async def create_bedrock_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncBedrockRuntimeClient:
+    """Helper to create an AsyncBedrockRuntimeClient for a given region."""
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://bedrock-runtime.{region}.amazonaws.com",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncBedrockRuntimeClient(
+        config=await AsyncBedrockRuntimeConfig.resolve(**overrides)
     )

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_bidirectional_streaming.py
@@ -9,6 +9,7 @@ import json
 import uuid
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_bedrock_runtime.models import (
     BidirectionalInputPayloadPart,
@@ -244,39 +245,40 @@ async def _receive_stream_output(
 
 async def test_invoke_model_with_bidirectional_stream() -> None:
     """Test bidirectional streaming with audio input and text/audio output."""
-    bedrock_client = await create_bedrock_client("us-east-1")
-
-    stream = await bedrock_client.invoke_model_with_bidirectional_stream(
-        InvokeModelWithBidirectionalStreamOperationInput(
-            model_id=BIDIRECTIONAL_MODEL_ID
+    async with await create_bedrock_client(
+        "us-east-1", transport=AWSCRTHTTPClient()
+    ) as bedrock_client:
+        stream = await bedrock_client.invoke_model_with_bidirectional_stream(
+            InvokeModelWithBidirectionalStreamOperationInput(
+                model_id=BIDIRECTIONAL_MODEL_ID
+            )
         )
-    )
 
-    prompt_name = str(uuid.uuid4())
-    content_name = str(uuid.uuid4())
-    audio_content_name = str(uuid.uuid4())
+        prompt_name = str(uuid.uuid4())
+        content_name = str(uuid.uuid4())
+        audio_content_name = str(uuid.uuid4())
 
-    init_events = [
-        START_SESSION_EVENT,
-        START_PROMPT_EVENT % prompt_name,
-        TEXT_CONTENT_START_EVENT % (prompt_name, content_name, "SYSTEM"),
-        TEXT_INPUT_EVENT % (prompt_name, content_name, DEFAULT_SYSTEM_PROMPT),
-        CONTENT_END_EVENT % (prompt_name, content_name),
-    ]
+        init_events = [
+            START_SESSION_EVENT,
+            START_PROMPT_EVENT % prompt_name,
+            TEXT_CONTENT_START_EVENT % (prompt_name, content_name, "SYSTEM"),
+            TEXT_INPUT_EVENT % (prompt_name, content_name, DEFAULT_SYSTEM_PROMPT),
+            CONTENT_END_EVENT % (prompt_name, content_name),
+        ]
 
-    for event in init_events:
-        await _send_event(stream, event)
+        for event in init_events:
+            await _send_event(stream, event)
 
-    await _send_event(
-        stream, AUDIO_CONTENT_START_EVENT % (prompt_name, audio_content_name)
-    )
+        await _send_event(
+            stream, AUDIO_CONTENT_START_EVENT % (prompt_name, audio_content_name)
+        )
 
-    results = await asyncio.gather(
-        _send_audio_chunks(stream, prompt_name, audio_content_name),
-        _receive_stream_output(stream),
-    )
-    got_text, got_audio, all_text_output = results[1]
+        results = await asyncio.gather(
+            _send_audio_chunks(stream, prompt_name, audio_content_name),
+            _receive_stream_output(stream),
+        )
+        got_text, got_audio, all_text_output = results[1]
 
-    assert got_text, "Expected to receive text output"
-    assert got_audio, "Expected to receive audio output"
-    assert len(all_text_output) > 0, "Expected non-empty text output"
+        assert got_text, "Expected to receive text output"
+        assert got_audio, "Expected to receive audio output"
+        assert len(all_text_output) > 0, "Expected non-empty text output"

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_non_streaming.py
@@ -15,23 +15,22 @@ from . import MESSAGE, MODEL_ID, create_bedrock_client
 
 
 async def test_converse() -> None:
-    bedrock_client = await create_bedrock_client("us-west-2")
+    async with await create_bedrock_client("us-west-2") as bedrock_client:
+        input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
+        response = await bedrock_client.converse(
+            ConverseInput(model_id=MODEL_ID, messages=[input_message])
+        )
 
-    input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
-    response = await bedrock_client.converse(
-        ConverseInput(model_id=MODEL_ID, messages=[input_message])
-    )
+        assert isinstance(response, ConverseOperationOutput)
+        assert isinstance(response.output, ConverseOutputMessage)
 
-    assert isinstance(response, ConverseOperationOutput)
-    assert isinstance(response.output, ConverseOutputMessage)
+        output_message = response.output.value
+        assert output_message.role == "assistant"
+        assert len(output_message.content) > 0
 
-    output_message = response.output.value
-    assert output_message.role == "assistant"
-    assert len(output_message.content) > 0
+        content_block = output_message.content[0]
+        assert isinstance(content_block, ContentBlockText)
+        assert isinstance(content_block.value, str) and content_block.value
 
-    content_block = output_message.content[0]
-    assert isinstance(content_block, ContentBlockText)
-    assert isinstance(content_block.value, str) and content_block.value
-
-    assert response.usage.input_tokens > 0
-    assert response.usage.output_tokens > 0
+        assert response.usage.input_tokens > 0
+        assert response.usage.output_tokens > 0

--- a/clients/aws-sdk-bedrock-runtime/tests/integration/test_output_streaming.py
+++ b/clients/aws-sdk-bedrock-runtime/tests/integration/test_output_streaming.py
@@ -17,29 +17,28 @@ from . import MESSAGE, MODEL_ID, create_bedrock_client
 
 
 async def test_converse_stream() -> None:
-    bedrock_client = await create_bedrock_client("us-west-2")
+    async with await create_bedrock_client("us-west-2") as bedrock_client:
+        input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
+        response = await bedrock_client.converse_stream(
+            ConverseStreamInput(model_id=MODEL_ID, messages=[input_message])
+        )
 
-    input_message = Message(role="user", content=[ContentBlockText(value=MESSAGE)])
-    response = await bedrock_client.converse_stream(
-        ConverseStreamInput(model_id=MODEL_ID, messages=[input_message])
-    )
+        received_text: list[str] = []
+        metadata_received = False
 
-    received_text: list[str] = []
-    metadata_received = False
+        async with response as stream:
+            async for event in stream.output_stream:
+                if isinstance(event, ConverseStreamOutputContentBlockDelta):
+                    delta = event.value.delta
+                    if isinstance(delta, ContentBlockDeltaText):
+                        received_text.append(delta.value)
+                elif isinstance(event, ConverseStreamOutputMetadata):
+                    metadata_received = True
+                    assert event.value.usage.input_tokens > 0
+                    assert event.value.usage.output_tokens > 0
 
-    async with response as stream:
-        async for event in stream.output_stream:
-            if isinstance(event, ConverseStreamOutputContentBlockDelta):
-                delta = event.value.delta
-                if isinstance(delta, ContentBlockDeltaText):
-                    received_text.append(delta.value)
-            elif isinstance(event, ConverseStreamOutputMetadata):
-                metadata_received = True
-                assert event.value.usage.input_tokens > 0
-                assert event.value.usage.output_tokens > 0
+            full_response = "".join(received_text)
+            assert full_response
 
-        full_response = "".join(received_text)
-        assert full_response
-
-        assert metadata_received
-        assert isinstance(stream.output, ConverseStreamOperationOutput)
+            assert metadata_received
+            assert isinstance(stream.output, ConverseStreamOperationOutput)

--- a/clients/aws-sdk-connecthealth/tests/integration/__init__.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/__init__.py
@@ -3,22 +3,29 @@
 
 from pathlib import Path
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_connecthealth.client import ConnectHealthClient
+from aws_sdk_connecthealth.client import AsyncConnectHealthClient
 from aws_sdk_connecthealth.config import AsyncConnectHealthConfig, Plugin
 
 REGION = "us-east-1"
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.wav"
 
 
-async def create_connecthealth_client(region: str) -> ConnectHealthClient:
-    return ConnectHealthClient(
-        config=await AsyncConnectHealthConfig.resolve(
-            endpoint_uri=f"https://health-agent.{region}.api.aws",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
+async def create_connecthealth_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncConnectHealthClient:
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://health-agent.{region}.api.aws",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncConnectHealthClient(
+        config=await AsyncConnectHealthConfig.resolve(**overrides)
     )
 
 

--- a/clients/aws-sdk-connecthealth/tests/integration/conftest.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/conftest.py
@@ -15,7 +15,7 @@ from typing import Any
 import boto3
 import pytest
 
-from aws_sdk_connecthealth.client import ConnectHealthClient
+from aws_sdk_connecthealth.client import AsyncConnectHealthClient
 from aws_sdk_connecthealth.models import (
     CreateDomainInput,
     CreateSubscriptionInput,
@@ -36,7 +36,7 @@ _SUBSCRIPTION_POLL_TIMEOUT_SECONDS = 300
 
 
 async def _wait_for_subscription_inactive(
-    client: ConnectHealthClient, domain_id: str, subscription_id: str
+    client: AsyncConnectHealthClient, domain_id: str, subscription_id: str
 ) -> None:
     """Wait for a Subscription to report INACTIVE.
 
@@ -64,7 +64,7 @@ async def _wait_for_subscription_inactive(
 
 
 async def _create_connecthealth_resources(
-    client: ConnectHealthClient, domain_name: str
+    client: AsyncConnectHealthClient, domain_name: str
 ) -> tuple[str, str]:
     """Create a ConnectHealth Domain and an ACTIVE Subscription.
 
@@ -87,7 +87,7 @@ async def _create_connecthealth_resources(
 
 
 async def _delete_connecthealth_resources(
-    client: ConnectHealthClient, domain_id: str | None, subscription_id: str | None
+    client: AsyncConnectHealthClient, domain_id: str | None, subscription_id: str | None
 ) -> None:
     """Deactivate the Subscription, then delete the Domain.
 
@@ -153,17 +153,16 @@ async def connecthealth_resources():
     bucket_name = f"integ-test-connecthealth-bucket-{unique_suffix}"
 
     s3_client = boto3.client("s3", region_name=REGION)
-    client = await create_connecthealth_client(REGION)
-
-    domain_id: str | None = None
-    subscription_id: str | None = None
-    try:
-        _create_s3_bucket(s3_client, bucket_name)
-        domain_id, subscription_id = await _create_connecthealth_resources(
-            client, domain_name
-        )
-        output_s3_uri = f"s3://{bucket_name}/clinical-notes/"
-        yield domain_id, subscription_id, output_s3_uri
-    finally:
-        await _delete_connecthealth_resources(client, domain_id, subscription_id)
-        _delete_s3_bucket(s3_client, bucket_name)
+    async with await create_connecthealth_client(REGION) as client:
+        domain_id: str | None = None
+        subscription_id: str | None = None
+        try:
+            _create_s3_bucket(s3_client, bucket_name)
+            domain_id, subscription_id = await _create_connecthealth_resources(
+                client, domain_name
+            )
+            output_s3_uri = f"s3://{bucket_name}/clinical-notes/"
+            yield domain_id, subscription_id, output_s3_uri
+        finally:
+            await _delete_connecthealth_resources(client, domain_id, subscription_id)
+            _delete_s3_bucket(s3_client, bucket_name)

--- a/clients/aws-sdk-connecthealth/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/test_bidirectional_streaming.py
@@ -8,6 +8,7 @@ import time
 import uuid
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_connecthealth.models import (
     ClinicalNoteGenerationSettings,
@@ -15,8 +16,8 @@ from aws_sdk_connecthealth.models import (
     EncounterContext,
     GetMedicalScribeListeningSessionInput,
     GetMedicalScribeListeningSessionOutput,
-    ManagedTemplate,
     ManagedNoteTemplate,
+    ManagedTemplate,
     MedicalScribeAudioEvent,
     MedicalScribeConfigurationEvent,
     MedicalScribeInputStream,
@@ -39,7 +40,6 @@ from aws_sdk_connecthealth.models import (
 )
 
 from . import AUDIO_FILE, REGION, create_connecthealth_client, streaming_endpoint_plugin
-
 
 SAMPLE_RATE = 16000
 BYTES_PER_SAMPLE = 2
@@ -70,7 +70,9 @@ async def _send_events(
                     ),
                 ),
                 encounter_context=EncounterContext(
-                    unstructured_context="Integration test encounter for SDK validation."
+                    unstructured_context=(
+                        "Integration test encounter for SDK validation."
+                    )
                 ),
             )
         )
@@ -157,59 +159,69 @@ async def test_start_medical_scribe_listening_session(connecthealth_resources) -
     """Test bidirectional streaming with audio input and transcript output."""
     domain_id, subscription_id, output_s3_uri = connecthealth_resources
 
-    client = await create_connecthealth_client(REGION)
-    endpoint_plugin = streaming_endpoint_plugin(REGION)
-    session_id = str(uuid.uuid4())
+    async with await create_connecthealth_client(
+        REGION, transport=AWSCRTHTTPClient()
+    ) as client:
+        endpoint_plugin = streaming_endpoint_plugin(REGION)
+        session_id = str(uuid.uuid4())
 
-    stream = await client.start_medical_scribe_listening_session(
-        input=StartMedicalScribeListeningSessionInput(
-            session_id=session_id,
-            domain_id=domain_id,
-            subscription_id=subscription_id,
-            language_code=MedicalScribeLanguageCode.EN_US,
-            media_sample_rate_hertz=SAMPLE_RATE,
-            media_encoding=MedicalScribeMediaEncoding.PCM,
-        ),
-        plugins=[endpoint_plugin],
-    )
+        stream = await client.start_medical_scribe_listening_session(
+            input=StartMedicalScribeListeningSessionInput(
+                session_id=session_id,
+                domain_id=domain_id,
+                subscription_id=subscription_id,
+                language_code=MedicalScribeLanguageCode.EN_US,
+                media_sample_rate_hertz=SAMPLE_RATE,
+                media_encoding=MedicalScribeMediaEncoding.PCM,
+            ),
+            plugins=[endpoint_plugin],
+        )
 
-    results = await asyncio.gather(
-        _send_events(stream, output_s3_uri),
-        _receive_events(stream, session_id, domain_id, subscription_id),
-    )
-    got_transcript = results[1]
-    assert got_transcript, (
-        "Expected to receive a transcript event with non-empty content"
-    )
+        results = await asyncio.gather(
+            _send_events(stream, output_s3_uri),
+            _receive_events(stream, session_id, domain_id, subscription_id),
+        )
+        got_transcript = results[1]
+        assert got_transcript, (
+            "Expected to receive a transcript event with non-empty content"
+        )
 
-    response = await client.get_medical_scribe_listening_session(
-        input=GetMedicalScribeListeningSessionInput(
-            session_id=session_id, domain_id=domain_id, subscription_id=subscription_id
-        ),
-        plugins=[endpoint_plugin],
-    )
-    assert isinstance(response, GetMedicalScribeListeningSessionOutput)
-    details = response.medical_scribe_listening_session_details
-    assert details is not None
-    assert details.session_id == session_id
-    assert details.stream_status == MedicalScribeStreamStatus.COMPLETED
-    assert details.language_code == MedicalScribeLanguageCode.EN_US
-    assert details.media_encoding == MedicalScribeMediaEncoding.PCM
-    assert details.media_sample_rate_hertz == SAMPLE_RATE
-    assert details.encounter_context_provided is True
-    assert isinstance(
-        details.post_stream_action_settings,
-        MedicalScribePostStreamActionSettingsResponse,
-    )
-    assert details.post_stream_action_settings.output_s3_uri == output_s3_uri
-    assert isinstance(
-        details.post_stream_action_settings.clinical_note_generation_settings,
-        ClinicalNoteGenerationSettingsResponse,
-    )
-    note_template = details.post_stream_action_settings.clinical_note_generation_settings.note_template_settings
-    assert isinstance(note_template, NoteTemplateSettingsResponseManagedTemplate)
-    assert note_template.value is not None
-    assert note_template.value.template_type == ManagedNoteTemplate.HISTORY_AND_PHYSICAL
-    assert details.post_stream_action_result is not None
-    assert details.stream_creation_time is not None
-    assert details.stream_end_time is not None
+        response = await client.get_medical_scribe_listening_session(
+            input=GetMedicalScribeListeningSessionInput(
+                session_id=session_id,
+                domain_id=domain_id,
+                subscription_id=subscription_id,
+            ),
+            plugins=[endpoint_plugin],
+        )
+        assert isinstance(response, GetMedicalScribeListeningSessionOutput)
+        details = response.medical_scribe_listening_session_details
+        assert details is not None
+        assert details.session_id == session_id
+        assert details.stream_status == MedicalScribeStreamStatus.COMPLETED
+        assert details.language_code == MedicalScribeLanguageCode.EN_US
+        assert details.media_encoding == MedicalScribeMediaEncoding.PCM
+        assert details.media_sample_rate_hertz == SAMPLE_RATE
+        assert details.encounter_context_provided is True
+        assert isinstance(
+            details.post_stream_action_settings,
+            MedicalScribePostStreamActionSettingsResponse,
+        )
+        assert details.post_stream_action_settings.output_s3_uri == output_s3_uri
+        assert isinstance(
+            details.post_stream_action_settings.clinical_note_generation_settings,
+            ClinicalNoteGenerationSettingsResponse,
+        )
+        clinical_note_settings = (
+            details.post_stream_action_settings.clinical_note_generation_settings
+        )
+        note_template = clinical_note_settings.note_template_settings
+        assert isinstance(note_template, NoteTemplateSettingsResponseManagedTemplate)
+        assert note_template.value is not None
+        assert (
+            note_template.value.template_type
+            == ManagedNoteTemplate.HISTORY_AND_PHYSICAL
+        )
+        assert details.post_stream_action_result is not None
+        assert details.stream_creation_time is not None
+        assert details.stream_end_time is not None

--- a/clients/aws-sdk-connecthealth/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-connecthealth/tests/integration/test_non_streaming.py
@@ -23,66 +23,66 @@ from . import REGION, create_connecthealth_client
 async def test_list_domains(connecthealth_resources) -> None:
     """Test non-streaming ListDomains operation."""
     _ = connecthealth_resources
-    client = await create_connecthealth_client(REGION)
+    async with await create_connecthealth_client(REGION) as client:
+        response = await client.list_domains(input=ListDomainsInput())
 
-    response = await client.list_domains(input=ListDomainsInput())
-
-    assert isinstance(response, ListDomainsOutput)
-    assert response.domains is not None
-    assert len(response.domains) >= 1
+        assert isinstance(response, ListDomainsOutput)
+        assert response.domains is not None
+        assert len(response.domains) >= 1
 
 
 async def test_get_domain(connecthealth_resources) -> None:
     """Test non-streaming GetDomain operation."""
     domain_id, _, _ = connecthealth_resources
-    client = await create_connecthealth_client(REGION)
+    async with await create_connecthealth_client(REGION) as client:
+        response = await client.get_domain(input=GetDomainInput(domain_id=domain_id))
 
-    response = await client.get_domain(input=GetDomainInput(domain_id=domain_id))
-
-    assert isinstance(response, GetDomainOutput)
-    assert response.domain_id == domain_id
-    assert response.status == DomainStatus.ACTIVE
-    assert response.name is not None
-    assert response.name.startswith("integ-test-connecthealth-domain-")
-    assert response.arn is not None
-    assert response.created_at is not None
-    assert response.encryption_context is not None
-    assert response.encryption_context.encryption_type == EncryptionType.AWS_OWNED_KEY
-    assert response.tags == {"Purpose": "IntegTest"}
+        assert isinstance(response, GetDomainOutput)
+        assert response.domain_id == domain_id
+        assert response.status == DomainStatus.ACTIVE
+        assert response.name is not None
+        assert response.name.startswith("integ-test-connecthealth-domain-")
+        assert response.arn is not None
+        assert response.created_at is not None
+        assert response.encryption_context is not None
+        assert (
+            response.encryption_context.encryption_type == EncryptionType.AWS_OWNED_KEY
+        )
+        assert response.tags == {"Purpose": "IntegTest"}
 
 
 async def test_list_subscriptions(connecthealth_resources) -> None:
     """Test non-streaming ListSubscriptions operation."""
     domain_id, subscription_id, _ = connecthealth_resources
-    client = await create_connecthealth_client(REGION)
+    async with await create_connecthealth_client(REGION) as client:
+        response = await client.list_subscriptions(
+            input=ListSubscriptionsInput(domain_id=domain_id)
+        )
 
-    response = await client.list_subscriptions(
-        input=ListSubscriptionsInput(domain_id=domain_id)
-    )
+        assert isinstance(response, ListSubscriptionsOutput)
+        assert response.subscriptions is not None
+        assert len(response.subscriptions) == 1
 
-    assert isinstance(response, ListSubscriptionsOutput)
-    assert response.subscriptions is not None
-    assert len(response.subscriptions) == 1
-
-    sub = response.subscriptions[0]
-    assert sub.subscription_id == subscription_id
-    assert sub.domain_id == domain_id
+        sub = response.subscriptions[0]
+        assert sub.subscription_id == subscription_id
+        assert sub.domain_id == domain_id
 
 
 async def test_get_subscription(connecthealth_resources) -> None:
     """Test non-streaming GetSubscription operation."""
     domain_id, subscription_id, _ = connecthealth_resources
-    client = await create_connecthealth_client(REGION)
+    async with await create_connecthealth_client(REGION) as client:
+        response = await client.get_subscription(
+            input=GetSubscriptionInput(
+                domain_id=domain_id, subscription_id=subscription_id
+            )
+        )
 
-    response = await client.get_subscription(
-        input=GetSubscriptionInput(domain_id=domain_id, subscription_id=subscription_id)
-    )
-
-    assert isinstance(response, GetSubscriptionOutput)
-    assert response.subscription is not None
-    assert response.subscription.subscription_id == subscription_id
-    assert response.subscription.domain_id == domain_id
-    assert response.subscription.status == SubscriptionStatus.ACTIVE
-    assert response.subscription.arn is not None
-    assert response.subscription.created_at is not None
-    assert response.subscription.last_updated_at is not None
+        assert isinstance(response, GetSubscriptionOutput)
+        assert response.subscription is not None
+        assert response.subscription.subscription_id == subscription_id
+        assert response.subscription.domain_id == domain_id
+        assert response.subscription.status == SubscriptionStatus.ACTIVE
+        assert response.subscription.arn is not None
+        assert response.subscription.created_at is not None
+        assert response.subscription.last_updated_at is not None

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/__init__.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/__init__.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_lex_runtime_v2.client import LexRuntimeV2Client
+from aws_sdk_lex_runtime_v2.client import AsyncLexRuntimeV2Client
 from aws_sdk_lex_runtime_v2.config import AsyncLexRuntimeV2Config
 
 BOT_ALIAS_ID = "TSTALIASID"
@@ -11,11 +13,16 @@ LOCALE_ID = "en_US"
 REGION = "us-east-1"
 
 
-async def create_lex_client(region: str) -> LexRuntimeV2Client:
-    return LexRuntimeV2Client(
-        config=await AsyncLexRuntimeV2Config.resolve(
-            endpoint_uri=f"https://runtime-v2-lex.{region}.amazonaws.com",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
+async def create_lex_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncLexRuntimeV2Client:
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://runtime-v2-lex.{region}.amazonaws.com",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncLexRuntimeV2Client(
+        config=await AsyncLexRuntimeV2Config.resolve(**overrides)
     )

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/test_bidirectional_streaming.py
@@ -7,23 +7,25 @@ import asyncio
 import uuid
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_lex_runtime_v2.models import (
+    ConfigurationEvent,
+    DisconnectionEvent,
     StartConversationInput,
+    StartConversationOutput,
     StartConversationRequestEventStream,
     StartConversationRequestEventStreamConfigurationEvent,
-    StartConversationRequestEventStreamTextInputEvent,
     StartConversationRequestEventStreamDisconnectionEvent,
+    StartConversationRequestEventStreamTextInputEvent,
     StartConversationResponseEventStream,
     StartConversationResponseEventStreamHeartbeatEvent,
     StartConversationResponseEventStreamIntentResultEvent,
     StartConversationResponseEventStreamTextResponseEvent,
     StartConversationResponseEventStreamTranscriptEvent,
-    StartConversationOutput,
-    ConfigurationEvent,
     TextInputEvent,
-    DisconnectionEvent,
 )
+
 from . import BOT_ALIAS_ID, LOCALE_ID, REGION, create_lex_client
 
 
@@ -125,22 +127,21 @@ async def _receive_events(
 
 async def test_start_conversation(lex_bot: str) -> None:
     """Test bidirectional streaming StartConversation operation."""
-    client = await create_lex_client(REGION)
-
-    stream = await client.start_conversation(
-        input=StartConversationInput(
-            bot_id=lex_bot,
-            bot_alias_id=BOT_ALIAS_ID,
-            locale_id=LOCALE_ID,
-            session_id=str(uuid.uuid4()),
-            conversation_mode="TEXT",
+    async with await create_lex_client(REGION, transport=AWSCRTHTTPClient()) as client:
+        stream = await client.start_conversation(
+            input=StartConversationInput(
+                bot_id=lex_bot,
+                bot_alias_id=BOT_ALIAS_ID,
+                locale_id=LOCALE_ID,
+                session_id=str(uuid.uuid4()),
+                conversation_mode="TEXT",
+            )
         )
-    )
 
-    results = await asyncio.gather(_send_events(stream), _receive_events(stream))
+        results = await asyncio.gather(_send_events(stream), _receive_events(stream))
 
-    got_transcript, got_intent_result, got_text_response, got_heartbeat = results[1]
-    assert got_transcript, "Expected to receive a TranscriptEvent"
-    assert got_intent_result, "Expected to receive an IntentResultEvent"
-    assert got_text_response, "Expected to receive a TextResponseEvent"
-    assert got_heartbeat, "Expected to receive a HeartbeatEvent"
+        got_transcript, got_intent_result, got_text_response, got_heartbeat = results[1]
+        assert got_transcript, "Expected to receive a TranscriptEvent"
+        assert got_intent_result, "Expected to receive an IntentResultEvent"
+        assert got_text_response, "Expected to receive a TextResponseEvent"
+        assert got_heartbeat, "Expected to receive a HeartbeatEvent"

--- a/clients/aws-sdk-lex-runtime-v2/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-lex-runtime-v2/tests/integration/test_non_streaming.py
@@ -6,43 +6,46 @@
 import uuid
 
 from aws_sdk_lex_runtime_v2.models import RecognizeTextInput, RecognizeTextOutput
+
 from . import BOT_ALIAS_ID, LOCALE_ID, REGION, create_lex_client
 
 
 async def test_recognize_text(lex_bot: str) -> None:
     """Test non-streaming RecognizeText operation."""
-    client = await create_lex_client(REGION)
-    response = await client.recognize_text(
-        input=RecognizeTextInput(
-            bot_id=lex_bot,
-            bot_alias_id=BOT_ALIAS_ID,
-            locale_id=LOCALE_ID,
-            session_id=str(uuid.uuid4()),
-            text="Hello",
+    async with await create_lex_client(REGION) as client:
+        response = await client.recognize_text(
+            input=RecognizeTextInput(
+                bot_id=lex_bot,
+                bot_alias_id=BOT_ALIAS_ID,
+                locale_id=LOCALE_ID,
+                session_id=str(uuid.uuid4()),
+                text="Hello",
+            )
         )
-    )
 
-    assert isinstance(response, RecognizeTextOutput)
-    assert response.session_id is not None
+        assert isinstance(response, RecognizeTextOutput)
+        assert response.session_id is not None
 
-    # Verify messages
-    assert response.messages is not None
-    assert len(response.messages) == 1
-    msg = response.messages[0]
-    assert msg.content_type == "PlainText"
-    assert msg.content == "Hello! How can I help you?"
+        # Verify messages
+        assert response.messages is not None
+        assert len(response.messages) == 1
+        msg = response.messages[0]
+        assert msg.content_type == "PlainText"
+        assert msg.content == "Hello! How can I help you?"
 
-    # Verify session state
-    assert response.session_state is not None
-    assert response.session_state.intent is not None
-    assert response.session_state.intent.name == "Greeting"
-    assert response.session_state.intent.state == "Fulfilled"
+        # Verify session state
+        assert response.session_state is not None
+        assert response.session_state.intent is not None
+        assert response.session_state.intent.name == "Greeting"
+        assert response.session_state.intent.state == "Fulfilled"
 
-    # Verify interpretations
-    assert response.interpretations is not None
-    assert len(response.interpretations) == 2
-    interps_by_name = {i.intent.name: i for i in response.interpretations if i.intent}
-    assert "Greeting" in interps_by_name
-    assert "FallbackIntent" in interps_by_name
-    assert interps_by_name["Greeting"].nlu_confidence is not None
-    assert interps_by_name["Greeting"].nlu_confidence.score == 1.0
+        # Verify interpretations
+        assert response.interpretations is not None
+        assert len(response.interpretations) == 2
+        interps_by_name = {
+            i.intent.name: i for i in response.interpretations if i.intent
+        }
+        assert "Greeting" in interps_by_name
+        assert "FallbackIntent" in interps_by_name
+        assert interps_by_name["Greeting"].nlu_confidence is not None
+        assert interps_by_name["Greeting"].nlu_confidence.score == 1.0

--- a/clients/aws-sdk-polly/examples/stream_speech_to_file.py
+++ b/clients/aws-sdk-polly/examples/stream_speech_to_file.py
@@ -4,8 +4,11 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "aws-sdk-polly~=0.6.0",
+#     "aws-sdk-polly[awscrt]",
 # ]
+#
+# [tool.uv.sources]
+# aws-sdk-polly = { path = "../" }
 # ///
 """
 Speech synthesis to a file using AWS Polly bidirectional streaming.
@@ -34,8 +37,9 @@ from pathlib import Path
 
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
-from aws_sdk_polly.client import PollyClient
+from aws_sdk_polly.client import AsyncPollyClient
 from aws_sdk_polly.config import AsyncPollyConfig
 from aws_sdk_polly.models import (
     CloseStreamEvent,
@@ -132,32 +136,32 @@ async def main():
     args = parse_args()
     text_chunks = get_text_chunks(args.text)
 
-    client = PollyClient(
+    async with AsyncPollyClient(
         config=await AsyncPollyConfig.resolve(
             endpoint_uri=f"https://polly.{args.region}.amazonaws.com",
             region=args.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            transport=AWSCRTHTTPClient(),
         )
-    )
-
-    stream = await client.start_speech_synthesis_stream(
-        input=StartSpeechSynthesisStreamInput(
-            engine="generative",
-            output_format="mp3",
-            sample_rate=str(SAMPLE_RATE),
-            voice_id=args.voice,
+    ) as client:
+        stream = await client.start_speech_synthesis_stream(
+            input=StartSpeechSynthesisStreamInput(
+                engine="generative",
+                output_format="mp3",
+                sample_rate=str(SAMPLE_RATE),
+                voice_id=args.voice,
+            )
         )
-    )
 
-    _, output_stream = await stream.await_output()
-    if output_stream is None:
-        raise RuntimeError("Polly stream did not return an output stream")
+        _, output_stream = await stream.await_output()
+        if output_stream is None:
+            raise RuntimeError("Polly stream did not return an output stream")
 
-    print("Synthesizing audio...")
-    await asyncio.gather(
-        send_text(stream.input_stream, text_chunks),
-        write_audio(output_stream, args.output),
-    )
+        print("Synthesizing audio...")
+        await asyncio.gather(
+            send_text(stream.input_stream, text_chunks),
+            write_audio(output_stream, args.output),
+        )
 
 
 if __name__ == "__main__":

--- a/clients/aws-sdk-polly/examples/stream_speech_to_speakers.py
+++ b/clients/aws-sdk-polly/examples/stream_speech_to_speakers.py
@@ -4,9 +4,12 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "aws-sdk-polly~=0.6.0",
+#     "aws-sdk-polly[awscrt]",
 #     "miniaudio~=1.71",
 # ]
+#
+# [tool.uv.sources]
+# aws-sdk-polly = { path = "../" }
 # ///
 """
 Real-time MP3 speech synthesis playback using AWS Polly bidirectional
@@ -38,8 +41,9 @@ from collections import deque
 import miniaudio
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
-from aws_sdk_polly.client import PollyClient
+from aws_sdk_polly.client import AsyncPollyClient
 from aws_sdk_polly.config import AsyncPollyConfig
 from aws_sdk_polly.models import (
     CloseStreamEvent,
@@ -238,29 +242,29 @@ async def main():
     args = parse_args()
     text_chunks = get_text_chunks(args.text)
 
-    client = PollyClient(
+    async with AsyncPollyClient(
         config=await AsyncPollyConfig.resolve(
             endpoint_uri=f"https://polly.{args.region}.amazonaws.com",
             region=args.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            transport=AWSCRTHTTPClient(),
         )
-    )
-
-    stream = await client.start_speech_synthesis_stream(
-        input=StartSpeechSynthesisStreamInput(
-            engine="generative",
-            output_format="mp3",
-            sample_rate=str(SAMPLE_RATE),
-            voice_id=args.voice,
+    ) as client:
+        stream = await client.start_speech_synthesis_stream(
+            input=StartSpeechSynthesisStreamInput(
+                engine="generative",
+                output_format="mp3",
+                sample_rate=str(SAMPLE_RATE),
+                voice_id=args.voice,
+            )
         )
-    )
 
-    _, output_stream = await stream.await_output()
+        _, output_stream = await stream.await_output()
 
-    print("Streaming MP3 audio to speakers...")
-    await asyncio.gather(
-        send_text(stream.input_stream, text_chunks), play_audio(output_stream)
-    )
+        print("Streaming MP3 audio to speakers...")
+        await asyncio.gather(
+            send_text(stream.input_stream, text_chunks), play_audio(output_stream)
+        )
 
 
 if __name__ == "__main__":

--- a/clients/aws-sdk-polly/tests/integration/__init__.py
+++ b/clients/aws-sdk-polly/tests/integration/__init__.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_polly.client import PollyClient
+from aws_sdk_polly.client import AsyncPollyClient
 from aws_sdk_polly.config import AsyncPollyConfig
 
 REGION = "us-east-1"
@@ -14,12 +16,15 @@ SAMPLE_RATE = "24000"
 TEST_TEXT = "Hello from the AWS SDK for Python Polly integration tests."
 
 
-async def create_polly_client(region: str) -> PollyClient:
-    """Helper to create a PollyClient for a given region."""
-    return PollyClient(
-        config=await AsyncPollyConfig.resolve(
-            endpoint_uri=f"https://polly.{region}.amazonaws.com",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
-    )
+async def create_polly_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncPollyClient:
+    """Helper to create an AsyncPollyClient for a given region."""
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://polly.{region}.amazonaws.com",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncPollyClient(config=await AsyncPollyConfig.resolve(**overrides))

--- a/clients/aws-sdk-polly/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_bidirectional_streaming.py
@@ -6,6 +6,7 @@
 import asyncio
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_polly.models import (
     CloseStreamEvent,
@@ -96,19 +97,20 @@ async def _receive_audio(
 
 async def test_start_speech_synthesis_stream() -> None:
     """Test bidirectional streaming with text input and audio output."""
-    client = await create_polly_client(REGION)
-
-    stream = await client.start_speech_synthesis_stream(
-        input=StartSpeechSynthesisStreamInput(
-            engine=ENGINE,
-            output_format=OUTPUT_FORMAT,
-            sample_rate=SAMPLE_RATE,
-            voice_id=VOICE_ID,
+    async with await create_polly_client(
+        REGION, transport=AWSCRTHTTPClient()
+    ) as client:
+        stream = await client.start_speech_synthesis_stream(
+            input=StartSpeechSynthesisStreamInput(
+                engine=ENGINE,
+                output_format=OUTPUT_FORMAT,
+                sample_rate=SAMPLE_RATE,
+                voice_id=VOICE_ID,
+            )
         )
-    )
 
-    results = await asyncio.gather(_send_text(stream), _receive_audio(stream))
-    audio_bytes, request_characters = results[1]
+        results = await asyncio.gather(_send_text(stream), _receive_audio(stream))
+        audio_bytes, request_characters = results[1]
 
-    assert audio_bytes > 0, "Expected to receive synthesized audio"
-    assert request_characters == len(TEST_TEXT)
+        assert audio_bytes > 0, "Expected to receive synthesized audio"
+        assert request_characters == len(TEST_TEXT)

--- a/clients/aws-sdk-polly/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_non_streaming.py
@@ -10,18 +10,19 @@ from . import ENGINE, REGION, VOICE_ID, create_polly_client
 
 async def test_describe_voices() -> None:
     """Test non-streaming DescribeVoices operation."""
-    client = await create_polly_client(REGION)
+    async with await create_polly_client(REGION) as client:
+        response = await client.describe_voices(
+            input=DescribeVoicesInput(engine=ENGINE)
+        )
 
-    response = await client.describe_voices(input=DescribeVoicesInput(engine=ENGINE))
+        assert isinstance(response, DescribeVoicesOutput)
+        assert response.voices is not None
+        assert len(response.voices) > 0
 
-    assert isinstance(response, DescribeVoicesOutput)
-    assert response.voices is not None
-    assert len(response.voices) > 0
+        voices_by_id = {voice.id: voice for voice in response.voices if voice.id}
+        assert VOICE_ID in voices_by_id
 
-    voices_by_id = {voice.id: voice for voice in response.voices if voice.id}
-    assert VOICE_ID in voices_by_id
-
-    voice = voices_by_id[VOICE_ID]
-    assert voice.language_code == "en-US"
-    assert voice.supported_engines is not None
-    assert ENGINE in voice.supported_engines
+        voice = voices_by_id[VOICE_ID]
+        assert voice.language_code == "en-US"
+        assert voice.supported_engines is not None
+        assert ENGINE in voice.supported_engines

--- a/clients/aws-sdk-polly/tests/integration/test_output_streaming.py
+++ b/clients/aws-sdk-polly/tests/integration/test_output_streaming.py
@@ -20,21 +20,20 @@ from . import (
 
 async def test_synthesize_speech() -> None:
     """Test output-streaming SynthesizeSpeech operation."""
-    client = await create_polly_client(REGION)
-
-    response = await client.synthesize_speech(
-        input=SynthesizeSpeechInput(
-            engine=ENGINE,
-            output_format=OUTPUT_FORMAT,
-            sample_rate=SAMPLE_RATE,
-            text=TEST_TEXT,
-            voice_id=VOICE_ID,
+    async with await create_polly_client(REGION) as client:
+        response = await client.synthesize_speech(
+            input=SynthesizeSpeechInput(
+                engine=ENGINE,
+                output_format=OUTPUT_FORMAT,
+                sample_rate=SAMPLE_RATE,
+                text=TEST_TEXT,
+                voice_id=VOICE_ID,
+            )
         )
-    )
 
-    assert isinstance(response, SynthesizeSpeechOutput)
-    assert response.content_type == "audio/mpeg"
-    assert response.request_characters == len(TEST_TEXT)
+        assert isinstance(response, SynthesizeSpeechOutput)
+        assert response.content_type == "audio/mpeg"
+        assert response.request_characters == len(TEST_TEXT)
 
-    audio = await read_streaming_blob_async(response.audio_stream)
-    assert len(audio) > 0
+        audio = await read_streaming_blob_async(response.audio_stream)
+        assert len(audio) > 0

--- a/clients/aws-sdk-qbusiness/tests/integration/__init__.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/__init__.py
@@ -1,20 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_qbusiness.client import QBusinessClient
+from aws_sdk_qbusiness.client import AsyncQBusinessClient
 from aws_sdk_qbusiness.config import AsyncQBusinessConfig
 
 REGION = "us-east-1"
 
 
-async def create_qbusiness_client(region: str) -> QBusinessClient:
-    """Helper to create a QBusinessClient for a given region."""
-    return QBusinessClient(
-        config=await AsyncQBusinessConfig.resolve(
-            endpoint_uri=f"https://qbusiness.{region}.api.aws",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
-    )
+async def create_qbusiness_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncQBusinessClient:
+    """Helper to create an AsyncQBusinessClient for a given region."""
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://qbusiness.{region}.api.aws",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncQBusinessClient(config=await AsyncQBusinessConfig.resolve(**overrides))

--- a/clients/aws-sdk-qbusiness/tests/integration/conftest.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/conftest.py
@@ -207,12 +207,12 @@ async def qbusiness_app():
     index_name = f"integ-test-qbusiness-index-{unique_suffix}"
     retriever_name = f"integ-test-qbusiness-retriever-{unique_suffix}"
 
-    client = await create_qbusiness_client(REGION)
-    application_id: str | None = None
-    try:
-        application_id = await _create_qbusiness_app(
-            client, app_name, index_name, retriever_name
-        )
-        yield application_id
-    finally:
-        await _delete_qbusiness_app(client, application_id)
+    async with await create_qbusiness_client(REGION) as client:
+        application_id: str | None = None
+        try:
+            application_id = await _create_qbusiness_app(
+                client, app_name, index_name, retriever_name
+            )
+            yield application_id
+        finally:
+            await _delete_qbusiness_app(client, application_id)

--- a/clients/aws-sdk-qbusiness/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/test_bidirectional_streaming.py
@@ -7,6 +7,7 @@ import asyncio
 import uuid
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_qbusiness.models import (
     ChatInput,
@@ -94,16 +95,19 @@ async def _receive_chat_output(
 
 async def test_chat_bidirectional_streaming(qbusiness_app: str) -> None:
     """Test bidirectional streaming with text input and chat output."""
-    qbusiness_client = await create_qbusiness_client(REGION)
+    async with await create_qbusiness_client(
+        REGION, transport=AWSCRTHTTPClient()
+    ) as qbusiness_client:
+        stream = await qbusiness_client.chat(
+            input=ChatInput(
+                application_id=qbusiness_app, client_token=str(uuid.uuid4())
+            )
+        )
 
-    stream = await qbusiness_client.chat(
-        input=ChatInput(application_id=qbusiness_app, client_token=str(uuid.uuid4()))
-    )
+        results = await asyncio.gather(
+            _send_chat_events(stream), _receive_chat_output(stream)
+        )
+        got_text_events, got_metadata_event = results[1]
 
-    results = await asyncio.gather(
-        _send_chat_events(stream), _receive_chat_output(stream)
-    )
-    got_text_events, got_metadata_event = results[1]
-
-    assert got_text_events, "Expected to receive text output events"
-    assert got_metadata_event, "Expected to receive a metadata event"
+        assert got_text_events, "Expected to receive text output events"
+        assert got_metadata_event, "Expected to receive a metadata event"

--- a/clients/aws-sdk-qbusiness/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-qbusiness/tests/integration/test_non_streaming.py
@@ -12,22 +12,21 @@ from . import REGION, create_qbusiness_client
 
 async def test_chat_sync(qbusiness_app: str) -> None:
     """Test non-streaming ChatSync operation."""
-    qbusiness_client = await create_qbusiness_client(REGION)
-
-    response = await qbusiness_client.chat_sync(
-        input=ChatSyncInput(
-            application_id=qbusiness_app,
-            user_message="Hello",
-            client_token=str(uuid.uuid4()),
+    async with await create_qbusiness_client(REGION) as qbusiness_client:
+        response = await qbusiness_client.chat_sync(
+            input=ChatSyncInput(
+                application_id=qbusiness_app,
+                user_message="Hello",
+                client_token=str(uuid.uuid4()),
+            )
         )
-    )
 
-    assert isinstance(response, ChatSyncOutput)
-    assert response.conversation_id is not None
-    assert response.system_message is not None
-    assert isinstance(response.system_message, str)
-    assert len(response.system_message) > 0
-    assert response.system_message_id is not None
-    assert response.user_message_id is not None
-    assert response.source_attributions is not None
-    assert response.failed_attachments is not None
+        assert isinstance(response, ChatSyncOutput)
+        assert response.conversation_id is not None
+        assert response.system_message is not None
+        assert isinstance(response.system_message, str)
+        assert len(response.system_message) > 0
+        assert response.system_message_id is not None
+        assert response.user_message_id is not None
+        assert response.source_attributions is not None
+        assert response.failed_attachments is not None

--- a/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
+++ b/clients/aws-sdk-transcribe-streaming/examples/simple_file.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "aiofile~=3.9.0",
-#     "aws-sdk-transcribe-streaming",
+#     "aws-sdk-transcribe-streaming[awscrt]",
 # ]
 #
 # [tool.uv.sources]
@@ -32,10 +32,11 @@ from pathlib import Path
 import aiofile
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_transcribe_streaming.client import (
+    AsyncTranscribeStreamingClient,
     StartStreamTranscriptionInput,
-    TranscribeStreamingClient,
 )
 from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 from aws_sdk_transcribe_streaming.models import (
@@ -63,7 +64,9 @@ async def apply_realtime_delay(
     sample_rate: float,
     channel_nums: int,
 ) -> None:
-    """Applies a delay when reading an audio file stream to simulate a real-time delay."""
+    """Applies a delay when reading an audio file stream to simulate a real-time
+    delay.
+    """
     start_time = time.time()
     elapsed_audio_time = 0.0
     async for chunk in reader:
@@ -117,34 +120,34 @@ async def write_chunks(audio_stream: EventPublisher[AudioStream]):
 
 async def main():
     # Initialize the Transcribe Streaming client
-    client = TranscribeStreamingClient(
+    async with AsyncTranscribeStreamingClient(
         config=await AsyncTranscribeStreamingConfig.resolve(
             endpoint_uri=ENDPOINT_URI,
             region=AWS_REGION,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            transport=AWSCRTHTTPClient(),
         )
-    )
-
-    # Start a streaming transcription session
-    stream = await client.start_stream_transcription(
-        input=StartStreamTranscriptionInput(
-            language_code="en-US",
-            media_sample_rate_hertz=SAMPLE_RATE,
-            media_encoding="pcm",
+    ) as client:
+        # Start a streaming transcription session
+        stream = await client.start_stream_transcription(
+            input=StartStreamTranscriptionInput(
+                language_code="en-US",
+                media_sample_rate_hertz=SAMPLE_RATE,
+                media_encoding="pcm",
+            )
         )
-    )
 
-    # Get the output stream for receiving transcription results
-    _, output_stream = await stream.await_output()
+        # Get the output stream for receiving transcription results
+        _, output_stream = await stream.await_output()
 
-    # Set up the handler for processing transcription events
-    handler = TranscriptResultStreamHandler(output_stream)
+        # Set up the handler for processing transcription events
+        handler = TranscriptResultStreamHandler(output_stream)
 
-    print("Transcribing audio from file...")
-    print("===============================")
+        print("Transcribing audio from file...")
+        print("===============================")
 
-    # Run audio streaming and transcription handling concurrently
-    await asyncio.gather(write_chunks(stream.input_stream), handler.handle_events())
+        # Run audio streaming and transcription handling concurrently
+        await asyncio.gather(write_chunks(stream.input_stream), handler.handle_events())
 
 
 if __name__ == "__main__":

--- a/clients/aws-sdk-transcribe-streaming/examples/simple_mic.py
+++ b/clients/aws-sdk-transcribe-streaming/examples/simple_mic.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "aws-sdk-transcribe-streaming",
+#     "aws-sdk-transcribe-streaming[awscrt]",
 #     "sounddevice~=0.5.3",
 # ]
 #
@@ -32,10 +32,11 @@ from typing import Any, AsyncGenerator, Tuple
 import sounddevice
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
 from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_transcribe_streaming.client import (
+    AsyncTranscribeStreamingClient,
     StartStreamTranscriptionInput,
-    TranscribeStreamingClient,
 )
 from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 from aws_sdk_transcribe_streaming.models import (
@@ -115,35 +116,35 @@ async def write_chunks(audio_stream: EventPublisher[AudioStream]):
 
 async def main():
     # Initialize the Transcribe Streaming client
-    client = TranscribeStreamingClient(
+    async with AsyncTranscribeStreamingClient(
         config=await AsyncTranscribeStreamingConfig.resolve(
             endpoint_uri=ENDPOINT_URI,
             region=AWS_REGION,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            transport=AWSCRTHTTPClient(),
         )
-    )
-
-    # Start a streaming transcription session
-    stream = await client.start_stream_transcription(
-        input=StartStreamTranscriptionInput(
-            language_code="en-US",
-            media_sample_rate_hertz=SAMPLE_RATE,
-            media_encoding="pcm",
+    ) as client:
+        # Start a streaming transcription session
+        stream = await client.start_stream_transcription(
+            input=StartStreamTranscriptionInput(
+                language_code="en-US",
+                media_sample_rate_hertz=SAMPLE_RATE,
+                media_encoding="pcm",
+            )
         )
-    )
 
-    # Get the output stream for receiving transcription results
-    _, output_stream = await stream.await_output()
+        # Get the output stream for receiving transcription results
+        _, output_stream = await stream.await_output()
 
-    # Set up the handler for processing transcription events
-    handler = TranscriptResultStreamHandler(output_stream)
+        # Set up the handler for processing transcription events
+        handler = TranscriptResultStreamHandler(output_stream)
 
-    print("Start talking to see transcription!")
-    print("(Press Ctrl+C to stop)")
-    print("===================================")
+        print("Start talking to see transcription!")
+        print("(Press Ctrl+C to stop)")
+        print("===================================")
 
-    # Run audio streaming and transcription handling concurrently
-    await asyncio.gather(write_chunks(stream.input_stream), handler.handle_events())
+        # Run audio streaming and transcription handling concurrently
+        await asyncio.gather(write_chunks(stream.input_stream), handler.handle_events())
 
 
 if __name__ == "__main__":

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/__init__.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/__init__.py
@@ -3,20 +3,27 @@
 
 from pathlib import Path
 
+from smithy_aws_core.config import AwsConfigOverrides
 from smithy_aws_core.identity import EnvironmentCredentialsResolver
+from smithy_http.aio.interfaces import HTTPClient
 
-from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
+from aws_sdk_transcribe_streaming.client import AsyncTranscribeStreamingClient
 from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig
 
 AUDIO_FILE = Path(__file__).parent / "assets" / "test.wav"
 
 
-async def create_transcribe_client(region: str) -> TranscribeStreamingClient:
-    """Helper to create a TranscribeStreamingClient for a given region."""
-    return TranscribeStreamingClient(
-        config=await AsyncTranscribeStreamingConfig.resolve(
-            endpoint_uri=f"https://transcribestreaming.{region}.amazonaws.com",
-            region=region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
+async def create_transcribe_client(
+    region: str, *, transport: HTTPClient | None = None
+) -> AsyncTranscribeStreamingClient:
+    """Helper to create an AsyncTranscribeStreamingClient for a given region."""
+    overrides: AwsConfigOverrides = {
+        "endpoint_uri": f"https://transcribestreaming.{region}.amazonaws.com",
+        "region": region,
+        "aws_credentials_identity_resolver": EnvironmentCredentialsResolver(),
+    }
+    if transport is not None:
+        overrides["transport"] = transport
+    return AsyncTranscribeStreamingClient(
+        config=await AsyncTranscribeStreamingConfig.resolve(**overrides)
     )

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_bidirectional_streaming.py
@@ -7,6 +7,7 @@ import asyncio
 import time
 
 from smithy_core.aio.eventstream import DuplexEventStream
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_transcribe_streaming.models import (
     AudioEvent,
@@ -21,7 +22,6 @@ from aws_sdk_transcribe_streaming.models import (
 )
 
 from . import AUDIO_FILE, create_transcribe_client
-
 
 SAMPLE_RATE = 16000
 BYTES_PER_SAMPLE = 2
@@ -88,20 +88,21 @@ async def _receive_transcription_output(
 
 async def test_start_stream_transcription() -> None:
     """Test bidirectional streaming with audio input and transcription output."""
-    transcribe_client = await create_transcribe_client("us-west-2")
-
-    stream = await transcribe_client.start_stream_transcription(
-        input=StartStreamTranscriptionInput(
-            language_code=LanguageCode.EN_US,
-            media_sample_rate_hertz=SAMPLE_RATE,
-            media_encoding=MediaEncoding.PCM,
+    async with await create_transcribe_client(
+        "us-west-2", transport=AWSCRTHTTPClient()
+    ) as transcribe_client:
+        stream = await transcribe_client.start_stream_transcription(
+            input=StartStreamTranscriptionInput(
+                language_code=LanguageCode.EN_US,
+                media_sample_rate_hertz=SAMPLE_RATE,
+                media_encoding=MediaEncoding.PCM,
+            )
         )
-    )
 
-    results = await asyncio.gather(
-        _send_audio_chunks(stream), _receive_transcription_output(stream)
-    )
-    got_transcript_events, transcripts = results[1]
+        results = await asyncio.gather(
+            _send_audio_chunks(stream), _receive_transcription_output(stream)
+        )
+        got_transcript_events, transcripts = results[1]
 
-    assert got_transcript_events, "Expected to receive transcript events"
-    assert len(transcripts) > 0, "Expected to receive at least one transcript"
+        assert got_transcript_events, "Expected to receive transcript events"
+        assert len(transcripts) > 0, "Expected to receive at least one transcript"

--- a/clients/aws-sdk-transcribe-streaming/tests/integration/test_non_streaming.py
+++ b/clients/aws-sdk-transcribe-streaming/tests/integration/test_non_streaming.py
@@ -8,6 +8,7 @@ import time
 import uuid
 
 from smithy_core.exceptions import CallError
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from aws_sdk_transcribe_streaming.models import (
     BadRequestException,
@@ -16,6 +17,7 @@ from aws_sdk_transcribe_streaming.models import (
     GetMedicalScribeStreamOutput,
     LanguageCode,
     LimitExceededException,
+    MediaEncoding,
     MedicalScribeAudioEvent,
     MedicalScribeConfigurationEvent,
     MedicalScribeInputStreamAudioEvent,
@@ -24,7 +26,6 @@ from aws_sdk_transcribe_streaming.models import (
     MedicalScribePostStreamAnalyticsSettings,
     MedicalScribeSessionControlEvent,
     MedicalScribeSessionControlEventType,
-    MediaEncoding,
     StartMedicalScribeStreamInput,
 )
 
@@ -43,77 +44,79 @@ ROLE_PROPAGATION_RETRY_DELAY = 5
 
 async def _run_medical_scribe_session(role_arn: str, s3_bucket: str) -> None:
     """Run a full Medical Scribe streaming session and verify its completion."""
-    transcribe_client = await create_transcribe_client("us-east-1")
-    session_id = str(uuid.uuid4())
+    async with await create_transcribe_client(
+        "us-east-1", transport=AWSCRTHTTPClient()
+    ) as transcribe_client:
+        session_id = str(uuid.uuid4())
 
-    stream = await transcribe_client.start_medical_scribe_stream(
-        input=StartMedicalScribeStreamInput(
-            language_code=LanguageCode.EN_US,
-            media_sample_rate_hertz=SAMPLE_RATE,
-            media_encoding=MediaEncoding.PCM,
-            session_id=session_id,
-        )
-    )
-
-    await stream.input_stream.send(
-        MedicalScribeInputStreamConfigurationEvent(
-            value=MedicalScribeConfigurationEvent(
-                resource_access_role_arn=role_arn,
-                post_stream_analytics_settings=MedicalScribePostStreamAnalyticsSettings(
-                    clinical_note_generation_settings=ClinicalNoteGenerationSettings(
-                        output_bucket_name=s3_bucket
-                    )
-                ),
+        stream = await transcribe_client.start_medical_scribe_stream(
+            input=StartMedicalScribeStreamInput(
+                language_code=LanguageCode.EN_US,
+                media_sample_rate_hertz=SAMPLE_RATE,
+                media_encoding=MediaEncoding.PCM,
+                session_id=session_id,
             )
         )
-    )
 
-    start_time = time.time()
-    elapsed_audio_time = 0.0
-
-    with AUDIO_FILE.open("rb") as f:
-        while chunk := f.read(CHUNK_SIZE):
-            await stream.input_stream.send(
-                MedicalScribeInputStreamAudioEvent(
-                    value=MedicalScribeAudioEvent(audio_chunk=chunk)
+        await stream.input_stream.send(
+            MedicalScribeInputStreamConfigurationEvent(
+                value=MedicalScribeConfigurationEvent(
+                    resource_access_role_arn=role_arn,
+                    post_stream_analytics_settings=MedicalScribePostStreamAnalyticsSettings(
+                        clinical_note_generation_settings=ClinicalNoteGenerationSettings(
+                            output_bucket_name=s3_bucket
+                        )
+                    ),
                 )
             )
-            elapsed_audio_time += len(chunk) / (
-                BYTES_PER_SAMPLE * SAMPLE_RATE * CHANNEL_NUMS
-            )
-            wait_time = start_time + elapsed_audio_time - time.time()
-            if wait_time > 0:
-                await asyncio.sleep(wait_time)
+        )
 
-    await stream.input_stream.send(
-        MedicalScribeInputStreamSessionControlEvent(
-            value=MedicalScribeSessionControlEvent(
-                type=MedicalScribeSessionControlEventType.END_OF_SESSION
+        start_time = time.time()
+        elapsed_audio_time = 0.0
+
+        with AUDIO_FILE.open("rb") as f:
+            while chunk := f.read(CHUNK_SIZE):
+                await stream.input_stream.send(
+                    MedicalScribeInputStreamAudioEvent(
+                        value=MedicalScribeAudioEvent(audio_chunk=chunk)
+                    )
+                )
+                elapsed_audio_time += len(chunk) / (
+                    BYTES_PER_SAMPLE * SAMPLE_RATE * CHANNEL_NUMS
+                )
+                wait_time = start_time + elapsed_audio_time - time.time()
+                if wait_time > 0:
+                    await asyncio.sleep(wait_time)
+
+        await stream.input_stream.send(
+            MedicalScribeInputStreamSessionControlEvent(
+                value=MedicalScribeSessionControlEvent(
+                    type=MedicalScribeSessionControlEventType.END_OF_SESSION
+                )
             )
         )
-    )
-    await stream.input_stream.close()
+        await stream.input_stream.close()
 
-    await stream.await_output()
+        await stream.await_output()
 
-    # Consume output stream events to properly close the connection
-    if stream.output_stream:
-        async for _ in stream.output_stream:
-            pass
+        # Consume output stream events to properly close the connection
+        if stream.output_stream:
+            async for _ in stream.output_stream:
+                pass
 
-    response = await transcribe_client.get_medical_scribe_stream(
-        input=GetMedicalScribeStreamInput(session_id=session_id)
-    )
+        response = await transcribe_client.get_medical_scribe_stream(
+            input=GetMedicalScribeStreamInput(session_id=session_id)
+        )
 
-    assert isinstance(response, GetMedicalScribeStreamOutput)
-    assert response.medical_scribe_stream_details is not None
+        assert isinstance(response, GetMedicalScribeStreamOutput)
+        assert response.medical_scribe_stream_details is not None
 
-    details = response.medical_scribe_stream_details
-    assert details.session_id == session_id
-    assert details.stream_status == "COMPLETED"
-    assert details.language_code == "en-US"
-    assert details.media_encoding == "pcm"
-    assert details.media_sample_rate_hertz == SAMPLE_RATE
+        details = response.medical_scribe_stream_details
+        assert details.session_id == session_id
+        assert details.stream_status == "COMPLETED"
+        assert details.language_code == "en-US"
+        assert details.media_encoding == "pcm"
+        assert details.media_sample_rate_hertz == SAMPLE_RATE
 
 
 async def test_get_medical_scribe_stream(


### PR DESCRIPTION
### Description

Updates integration tests and streaming examples for the upcoming Smithy Python client changes:

- Use the required `Async`-prefixed client names.
- Manage clients with async context managers.
- Use the default `AIOHTTPClient` transport for ordinary operations.
- Explicitly configure `AWSCRTHTTPClient` for bidirectional streaming workflows.
- Install the generated `awscrt` extra in bidirectional streaming examples.

Existing test setup, operation inputs, outputs, assertions, and workflows are otherwise unchanged. The Transcribe Medical Scribe workflow continues using one CRT client because it begins with a bidirectional operation.

#### Related Smithy Python Changes

- [smithy-lang/smithy-python#781](https://github.com/smithy-lang/smithy-python/pull/781): defaults generated AWS clients to aiohttp and removes deprecated client aliases.
- [smithy-lang/smithy-python#765](https://github.com/smithy-lang/smithy-python/pull/765): adds client and transport cleanup through `close()` and async context managers.
- [aiohttp query and Content-Type fix](https://github.com/smithy-lang/smithy-python/tree/fix-aiohttp-query-and-content-type): preserves URI query parameters and avoids adding an implicit `Content-Type`.
  - fixes operations for `aws-sdk-qbusiness` and `aws-sdk-connecthealth` after migration to aiohttp default

#### Installation
For tests requiring the CRT client, installation must now include the `awscrt` extra:
```shell
uv pip install -e ".[awscrt]" --group test
```

### Testing

Successfully ran an internal development release that included:

- The aiohttp query and Content-Type fix
- The open PR to default generated clients to aiohttp and remove deprecated aliases
- This integration-test update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
